### PR TITLE
Issue #43 - make app_id configurable

### DIFF
--- a/custom_components/lennoxs30/manifest.json
+++ b/custom_components/lennoxs30/manifest.json
@@ -1,11 +1,11 @@
 {
     "domain": "lennoxs30",
     "name": "Lennox S30 Cloud Integration",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "documentation": "https://github.com/PeteRager/lennoxs30",
     "issuetracker" : "https://github.com/PeteRager/lennoxs30/issues",
     "dependencies": [],
-    "requirements": ["lennoxs30api==0.0.8"],
+    "requirements": ["lennoxs30api==0.0.9"],
     "codeowners": ["@PeteRager"],
     "iot_class": "cloud_polling"
   }


### PR DESCRIPTION
Sometimes for reasons we do not understand, generating a unique app_id for some lennox accounts results in no messages being delivered to the application.  This change allows a unique app id to be statically specified in configuration.yaml to work around this issue.