### PR TITLE
#81 #82 -Add filters to system subscriptions

### DIFF
--- a/custom_components/lennoxs30/climate.py
+++ b/custom_components/lennoxs30/climate.py
@@ -120,7 +120,9 @@ class S30Climate(ClimateEntity):
         self._zone = zone
         self._zone.registerOnUpdateCallback(self.zone_update_callback)
         # We need notification of state of system.manualAwayMode in order to update the preset mode in HA.
-        self._system.registerOnUpdateCallback(self.system_update_callback)
+        self._system.registerOnUpdateCallback(
+            self.system_update_callback, ["manualAwayMode"]
+        )
         self._myname = self._system.name + "_" + self._zone.name
         ### For development testing.  We need a better way to enable this.  DO NOT CHECK IT IN WITH THIS AS TRUE!!!!!!
         self._sim_mode = False

--- a/custom_components/lennoxs30/switch.py
+++ b/custom_components/lennoxs30/switch.py
@@ -64,7 +64,15 @@ class S30VentilationSwitch(SwitchEntity):
         self._hass = hass
         self._manager = manager
         self._system = system
-        self._system.registerOnUpdateCallback(self.update_callback)
+        self._system.registerOnUpdateCallback(
+            self.update_callback,
+            [
+                "ventilationRemainingTime",
+                "ventilatingUntilTime",
+                "diagVentilationRuntime",
+                "ventilationMode",
+            ],
+        )
         self._myname = self._system.name + "_ventilation"
 
     def update_callback(self):
@@ -130,7 +138,9 @@ class S30AllergenDefenderSwitch(SwitchEntity):
         self._hass = hass
         self._manager = manager
         self._system = system
-        self._system.registerOnUpdateCallback(self.update_callback)
+        self._system.registerOnUpdateCallback(
+            self.update_callback, ["allergenDefender"]
+        )
         self._myname = self._system.name + "_allergen_defender"
 
     def update_callback(self):


### PR DESCRIPTION
Resolving performance issues with climate and switch entities refreshing when-ever a system property changes.  Add match filters