### PR TITLE
Change update_callback to debug log level

### DIFF
--- a/custom_components/lennoxs30/sensor.py
+++ b/custom_components/lennoxs30/sensor.py
@@ -99,7 +99,7 @@ class S30OutdoorTempSensor(SensorEntity):
         self._myname = self._system.name + "_outdoor_temperature"
 
     def update_callback(self):
-        _LOGGER.info(f"update_callback S30OutdoorTempSensor myname [{self._myname}]")
+        _LOGGER.debug(f"update_callback S30OutdoorTempSensor myname [{self._myname}]")
         self.schedule_update_ha_state()
 
     @property
@@ -159,7 +159,7 @@ class S30TempSensor(SensorEntity):
         self._myname = self._zone._system.name + "_" + self._zone.name + "_temperature"
 
     def update_callback(self):
-        _LOGGER.info(f"update_callback S30TempSensor myname [{self._myname}]")
+        _LOGGER.debug(f"update_callback S30TempSensor myname [{self._myname}]")
         self.schedule_update_ha_state()
 
     @property
@@ -219,7 +219,7 @@ class S30HumiditySensor(SensorEntity):
         self._myname = self._zone._system.name + "_" + self._zone.name + "_humidity"
 
     def update_callback(self):
-        _LOGGER.info(f"update_callback S30HumiditySensor myname [{self._myname}]")
+        _LOGGER.debug(f"update_callback S30HumiditySensor myname [{self._myname}]")
         self.schedule_update_ha_state()
 
     @property
@@ -278,7 +278,7 @@ class S30InverterPowerSensor(SensorEntity):
         self._myname = self._system.name + "_inverter_energy"
 
     def update_callback(self):
-        _LOGGER.info(f"update_callback myname [{self._myname}]")
+        _LOGGER.debug(f"update_callback S30InverterPowerSensor [{self._myname}]")
         self.schedule_update_ha_state()
 
     @property


### PR DESCRIPTION
After trying the new release on my main HASS install, I realized that this callback was unnecessarily verbose on the default log level.