### PR TITLE
Unique setup popups for Cloud and Local

### DIFF
--- a/custom_components/lennoxs30/climate.py
+++ b/custom_components/lennoxs30/climate.py
@@ -71,8 +71,7 @@ DOMAIN = "lennoxs30"
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> bool:
     _LOGGER.debug("climate:async_setup_platform enter")
     climate_list = []
-    hub_name = entry.data[CONF_NAME]
-    manager: Manager = hass.data[DOMAIN][hub_name]["hub"]
+    manager: Manager = hass.data[DOMAIN][entry.unique_id]["hub"]
     for system in manager._api.getSystems():
         for zone in system.getZones():
             if zone.is_zone_active() == True:

--- a/custom_components/lennoxs30/config_flow.py
+++ b/custom_components/lennoxs30/config_flow.py
@@ -23,6 +23,7 @@ CONF_APP_ID = "app_id"
 CONF_INIT_WAIT_TIME = "init_wait_time"
 CONF_CREATE_SENSORS = "create_sensors"
 CONF_CREATE_INVERTER_POWER = "create_inverter_power"
+CONF_CLOUD_LOCAL = "cloud_local"
 
 DEFAULT_POLL_INTERVAL: int = 10
 DEFAULT_FAST_POLL_INTERVAL: float = 0.75
@@ -31,36 +32,33 @@ RETRY_INTERVAL_SECONDS = 60
 DOMAIN = "lennoxs30"
 _LOGGER = logging.getLogger(__name__)
 
-DATA_SCHEMA = vol.Schema(
+
+
+STEP_ONE = vol.Schema(
     {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_NAME, default="S30"): cv.string,
-                vol.Required(CONF_EMAIL): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Required(CONF_HOSTS): cv.string,
-                vol.Optional(CONF_SCAN_INTERVAL): cv.positive_int,
-                vol.Optional(
-                    CONF_FAST_POLL_INTERVAL, default=DEFAULT_FAST_POLL_INTERVAL
-                ): cv.positive_float,
-                vol.Optional(CONF_ALLERGEN_DEFENDER_SWITCH, default=False): cv.boolean,
-                vol.Optional(CONF_APP_ID): cv.string,
-                vol.Optional(CONF_INIT_WAIT_TIME, default=30): cv.positive_int,
-                vol.Optional(CONF_CREATE_SENSORS, default=False): cv.boolean,
-                vol.Optional(CONF_CREATE_INVERTER_POWER, default=False): cv.boolean,
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
+        vol.Required(CONF_CLOUD_LOCAL, default = False): cv.boolean,
+    }
 )
 
-STEP_DOMAIN = vol.Schema(
+STEP_CLOUD = vol.Schema(
     {
-        vol.Required(CONF_NAME, default="S30"): cv.string,
         vol.Required(CONF_EMAIL): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Required(CONF_HOSTS): cv.string,
         vol.Optional(CONF_APP_ID): cv.string,
+        vol.Optional(CONF_INIT_WAIT_TIME, default=30): cv.positive_int,
+        vol.Optional(CONF_ALLERGEN_DEFENDER_SWITCH, default=False): cv.boolean,
+        vol.Optional(CONF_CREATE_SENSORS, default=False): cv.boolean,
+        vol.Optional(CONF_CREATE_INVERTER_POWER, default=False): cv.boolean,
+        vol.Optional(CONF_SCAN_INTERVAL): cv.positive_int,
+        vol.Optional(
+            CONF_FAST_POLL_INTERVAL, default=DEFAULT_FAST_POLL_INTERVAL
+        ): cv.positive_float,
+    }
+)
+
+STEP_LOCAL= vol.Schema(
+    {
+        vol.Required(CONF_HOSTS): cv.string,
         vol.Optional(CONF_INIT_WAIT_TIME, default=30): cv.positive_int,
         vol.Optional(CONF_ALLERGEN_DEFENDER_SWITCH, default=False): cv.boolean,
         vol.Optional(CONF_CREATE_SENSORS, default=False): cv.boolean,
@@ -106,7 +104,33 @@ class lennoxs30ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}
-
+        if user_input is not None:
+            cloud_local = user_input[CONF_CLOUD_LOCAL]
+            if cloud_local:
+                return await self.async_step_cloud()
+            else:
+                return await self.async_step_local()
+     
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_ONE, errors=errors
+        )
+        
+    async def async_step_cloud(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}       
+        if user_input is not None:
+            await self.async_set_unique_id("lennoxs30"+user_input[CONF_EMAIL])
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title=user_input[CONF_EMAIL], data=user_input
+            )
+        return self.async_show_form(
+            step_id="cloud", data_schema=STEP_CLOUD, errors=errors
+        )
+        
+    async def async_step_local(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}       
         if user_input is not None:
             host = user_input[CONF_HOSTS]
             if host != "Cloud":
@@ -115,15 +139,16 @@ class lennoxs30ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 elif not host_valid(user_input[CONF_HOSTS]):
                     errors[CONF_HOSTS] = "invalid host IP"
                 else:
-                    await self.async_set_unique_id(user_input[CONF_HOSTS])
+                    await self.async_set_unique_id("lennoxs30"+user_input[CONF_HOSTS])
                     self._abort_if_unique_id_configured()
                     return self.async_create_entry(
                         title=user_input[CONF_HOSTS], data=user_input
-                    )
-
+                    )    
         return self.async_show_form(
-            step_id="user", data_schema=STEP_DOMAIN, errors=errors
+            step_id="local", data_schema=STEP_LOCAL, errors=errors
         )
+
+        
 
     async def async_step_import(self, user_input) -> FlowResult:
         """Handle the import step."""

--- a/custom_components/lennoxs30/sensor.py
+++ b/custom_components/lennoxs30/sensor.py
@@ -32,8 +32,8 @@ DOMAIN = "lennoxs30"
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> bool:
 
     sensor_list = []
-    hub_name = entry.data[CONF_NAME]
-    manager: Manager = hass.data[DOMAIN][hub_name]["hub"]
+
+    manager: Manager = hass.data[DOMAIN][entry.unique_id]["hub"]
     for system in manager._api.getSystems():
         _LOGGER.info(f"Create S30OutdoorTempSensor sensor system [{system.sysId}]")
         sensor = S30OutdoorTempSensor(hass, manager, system)

--- a/custom_components/lennoxs30/strings.json
+++ b/custom_components/lennoxs30/strings.json
@@ -1,20 +1,37 @@
 {
   "config": {
-    "title": "Lennox S30 Local/Cloud",
+    "title": "Lennox S30/E30 Local/Cloud",
     "step": {
       "user": {
-        "title": "Define your Lennox S30 connection",
+        "title": "Define your Lennox S30/E30 connection",
         "data": {
-			"name": "Name you want to use for this copy of the intergration",
+			"cloud_local": "Check if you like to make a cloud connection."
+        }
+      },
+	  "cloud": {
+        "title": "Define your Lennox S30/E30 connection",
+        "data": {
 			"email": "Your email, or \"Local\" if using local lan",
 			"password": "Your password, or \"Local\" if using local lan",
-			"ip_address": "The Local IP or Hostname of your Lennox S30, or \"None\" if using cloud",
 			"scan_interval": "Scan interval to check for messages in seconds. 15 seconds is recommened for cloud connections. For local connections this sbould be set to 1",
 			"fast_scan_interval": "After issuing a command (setpoint change, hvac mode change, etc.) The system goes into a fast scan mode, in order to make the UI more responsive to commands",
 			"allergen_defender_switch": "Create a switch entity to allow control of allergenDefender mode",
 			"app_id": "Specify the unique application id to use. In most cases, having the integration autogenerate one works fine. See documentation",
 			"init_wait_time": "Amount of time to wait for configuration to arrive from Lennox during integration startup. Increase this value if you see initialization timeouts",
-			"create_sensors": "Create Sensors"
+			"create_sensors": "Create Sensors",
+			"create_inverter_power": "Create Sensor for inverter power"
+        }
+      },
+	  "local": {
+        "title": "Define your Lennox S30/E30 connection",
+        "data": {
+			"hosts": "The Local IP or Hostname of your Lennox S30/E30, or \"None\" if using cloud",
+			"scan_interval": "Scan interval to check for messages in seconds. 15 seconds is recommened for cloud connections. For local connections this sbould be set to 1",
+			"fast_scan_interval": "After issuing a command (setpoint change, hvac mode change, etc.) The system goes into a fast scan mode, in order to make the UI more responsive to commands",
+			"allergen_defender_switch": "Create a switch entity to allow control of allergenDefender mode",
+			"app_id": "Specify the unique application id to use. In most cases, having the integration autogenerate one works fine. See documentation",
+			"init_wait_time": "Amount of time to wait for configuration to arrive from Lennox during integration startup. Increase this value if you see initialization timeouts",
+			"create_sensors": "Create Sensors",
 			"create_inverter_power": "Create Sensor for inverter power"
         }
       }

--- a/custom_components/lennoxs30/switch.py
+++ b/custom_components/lennoxs30/switch.py
@@ -19,8 +19,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     _LOGGER.debug("switch:async_setup_platform enter")
 
     switch_list = []
-    hub_name = entry.data[CONF_NAME]
-    manager: Manager = hass.data[DOMAIN][hub_name]["hub"]
+    manager: Manager = hass.data[DOMAIN][entry.unique_id]["hub"]
     for system in manager._api.getSystems():
         _LOGGER.info(
             f"async_setup_platform ventilation [{system.supports_ventilation()}]"

--- a/custom_components/lennoxs30/translations/en.json
+++ b/custom_components/lennoxs30/translations/en.json
@@ -1,14 +1,31 @@
 {
   "config": {
-    "title": "Lennox S30 Local/Cloud",
+    "title": "Lennox S30/E30 Local/Cloud",
     "step": {
       "user": {
-        "title": "Define your Lennox S30 connection",
+        "title": "Define your Lennox S30/E30 connection",
         "data": {
-			"name": "Name you want to use for this copy of the intergration",
+			"cloud_local": "Check if you like to make a cloud connection."
+        }
+      },
+	  "cloud": {
+        "title": "Define your Lennox S30/E30 connection",
+        "data": {
 			"email": "Your email, or \"Local\" if using local lan",
 			"password": "Your password, or \"Local\" if using local lan",
-			"hosts": "The Local IP or Hostname of your Lennox S30, or \"None\" if using cloud",
+			"scan_interval": "Scan interval to check for messages in seconds. 15 seconds is recommened for cloud connections. For local connections this sbould be set to 1",
+			"fast_scan_interval": "After issuing a command (setpoint change, hvac mode change, etc.) The system goes into a fast scan mode, in order to make the UI more responsive to commands",
+			"allergen_defender_switch": "Create a switch entity to allow control of allergenDefender mode",
+			"app_id": "Specify the unique application id to use. In most cases, having the integration autogenerate one works fine. See documentation",
+			"init_wait_time": "Amount of time to wait for configuration to arrive from Lennox during integration startup. Increase this value if you see initialization timeouts",
+			"create_sensors": "Create Sensors",
+			"create_inverter_power": "Create Sensor for inverter power"
+        }
+      },
+	  "local": {
+        "title": "Define your Lennox S30/E30 connection",
+        "data": {
+			"hosts": "The Local IP or Hostname of your Lennox S30/E30, or \"None\" if using cloud",
 			"scan_interval": "Scan interval to check for messages in seconds. 15 seconds is recommened for cloud connections. For local connections this sbould be set to 1",
 			"fast_scan_interval": "After issuing a command (setpoint change, hvac mode change, etc.) The system goes into a fast scan mode, in order to make the UI more responsive to commands",
 			"allergen_defender_switch": "Create a switch entity to allow control of allergenDefender mode",


### PR DESCRIPTION
I unavailable unexpectedly.
This implements part of the intended functionality:
It asks the operator weather they want a Cloud or Local connation, then gives a connection specific prompt.
It also better-handles unique id creation during setup, the previous system of having the user enter the name was convenient but could result in problems if they entered two connections with the same name.

It does not yet implement the other requested features,  but wanted to put it out there as better then nothing.