### PR TITLE
Support for Smart Away

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,16 @@
 {
   "python.testing.pytestArgs": ["tests"],
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true
+  "python.testing.pytestEnabled": true,
+  "cSpell.words": [
+    "HACS",
+    "heatpump",
+    "HVAC",
+    "Lennox",
+    "lennoxicomfort",
+    "lennoxs",
+    "Setpoint",
+    "setpoints",
+    "sysuptime"
+  ]
 }

--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,8 @@
 # Lennox S30/E30 Component
 
 A custom component for Home Assistant to integrate with Lennox iComfort S30, E30 or M30 thermostats; supporting local LAN connections and Lennox
-Cloud Connections depending on the device model.  We believe these configurations work - let us know if your experience is different!
+Cloud Connections depending on the device model. We believe these configurations work - let us know if your experience is different!
+
 - S30 - cloud or local connections
 - E30 - cloud or local connections
 - M30 - cloud connections only.
@@ -26,7 +27,7 @@ Cloud Connections depending on the device model.  We believe these configuration
 
 ## HACS
 
-HACS is recommended as it provides automated install and will notify you whem updates are available.
+HACS is recommended as it provides automated install and will notify you when updates are available.
 
 This assumes you have [HACS](https://github.com/hacs/integration) installed and know how to use it. If you need help with this, go to the HACS project documentation.
 
@@ -49,9 +50,9 @@ Add integration in _HACS_
 ## Manually
 
 1. Go to [releases](https://github.com/PeteRager/lennoxs30/releases) in this repo and download the latest zip or clone the repo
-1. Extract the zip file and copy the `custom_components/lennoxs30` folder and all it's contents including the `translations` subfolder, into the `custom_components` folder in your HA installation. If upgrading from a prior release, pleast remove ALL files from this folder.
+1. Extract the zip file and copy the `custom_components/lennoxs30` folder and all it's contents including the `translations` subfolder, into the `custom_components` folder in your HA installation. If upgrading from a prior release, please remove ALL files from this folder.
 1. Restart HA.
-1. Follow the Configuration Instuctions below
+1. Follow the Configuration Instructions below
 
 # Configuration
 
@@ -71,13 +72,13 @@ Why would you use a Cloud Connection? Perhaps you want to monitor your vacation 
 
 Need both or have multiple S30s? You are able to run multiple local and multiple cloud connections at the same time. Each is configured using this process.
 
-1. Select Cloud or Local (default) connetion
+1. Select Cloud or Local (default) connection
 
 ## Local Configuration
 
 The next step is providing the connection information.
 
-1. Enter the IP address of the S30. Alternatvely, you can use a DNS name. If you have firewalls and do port mapping you may specify the port (hostname:port or ip:port) By default the S30 exposes HTTPS on Port 443.
+1. Enter the IP address of the S30. Alternatively, you can use a DNS name. If you have firewalls and do port mapping you may specify the port (hostname:port or ip:port) By default the S30 exposes HTTPS on Port 443.
 1. You can use the defaults for the rest of the fields, or adjust as needed. See detailed configuration parameters below. Configuration can be changed later when needed. See [Detailed Configuration](#Detailed-Configuration-Parameters)
 1. Submit the form
 
@@ -85,9 +86,9 @@ At this point, the integration will attempt to connect to the S30 - this should 
 
 ## Cloud Connection
 
-If using a cloud conection. The next step is to specifiy the connection information.
+If using a cloud connection. The next step is to specify the connection information.
 
-1. Enter the email address associated with your Lennox iComfort acount
+1. Enter the email address associated with your Lennox iComfort account
 1. Enter the password associated with your Lennox iComfort account
 1. Use the defaults for the rest of the fields, or adjust as needed. See [Detailed Configuration](#Detailed-Configuration-Parameters)
 1. Submit the form
@@ -101,7 +102,7 @@ The next page brings up advanced configuration properties with the recommended d
 1. Use the defaults (recommended) or adjust using the [Detailed Configuration](#Detailed-Configuration-Parameters)
 1. Press submit
 
-At this point, the integration will connect to the S30, download and process its configuration (100kb) and create the Entities in Home Assistant. For local connections, this step typically takes 10-30 seconds complete, for cloud connections it an takes 15-45 seconds. If it is succesful, you will be presented with a list of discovered devices. If it fails, review the error and look in the log file for more detailed information.
+At this point, the integration will connect to the S30, download and process its configuration (100kb) and create the Entities in Home Assistant. For local connections, this step typically takes 10-30 seconds complete, for cloud connections it an takes 15-45 seconds. If it is successful, you will be presented with a list of discovered devices. If it fails, review the error and look in the log file for more detailed information.
 
 For Local Connections the Integration instance name is the ip_address / host name. For Cloud Connections the instance name is a redacted version of your email.
 
@@ -111,7 +112,7 @@ If you want to change the integration configuration, do into the integrations pa
 
 # Temperature Units (Celsius, Fahrenheit)
 
-The integration detects the unit system configured in Home Assistant and reports the data in the correct units. Celsius is in 0.5 degree increments. Fahrenheit is in 1.0 degress increments. The Lennox API delivers data in both units, so there is no conversion in the Integration and what you see in the Lennox UI should be what you see in HA.
+The integration detects the unit system configured in Home Assistant and reports the data in the correct units. Celsius is in 0.5 degree increments. Fahrenheit is in 1.0 degrees increments. The Lennox API delivers data in both units, so there is no conversion in the Integration and what you see in the Lennox UI should be what you see in HA.
 
 # Devices
 
@@ -119,9 +120,9 @@ The integration will create a full set of devices representing your HVAC system.
 
 | Device Type  | Description                                                                                           | Name                           | Parent |
 | ------------ | ----------------------------------------------------------------------------------------------------- | ------------------------------ | ------ |
-| S30          | This is the HVAC contoller, it is a little box with an antenna located near the indoor unit.          | S30 System Name                | None   |
+| S30          | This is the HVAC controller, it is a little box with an antenna located near the indoor unit.         | S30 System Name                | None   |
 | Indoor Unit  | This specifies the type of indoor unit you have. Examples, include `Furnace` and `Air Handler`.       | S30 System Name + Outdoor Unit | S30    |
-| Outdoor Unit | This specifies the tyoe of outdoor unit you have. Examples include `Heat Pump` and `Air Conditione`r. | S30 System Name + Indoor Unit  | S30    |
+| Outdoor Unit | This specifies the type of outdoor unit you have. Examples include `Heat Pump` and `Air Conditione`r. | S30 System Name + Indoor Unit  | S30    |
 | Thermostat   | One thermostat device is created for each zone. These are mounted on the walls in your house.         | S30 System Name + Zone Name    | S30    |
 
 # Entities
@@ -130,7 +131,7 @@ The integration will create a full set of devices representing your HVAC system.
 
 _Cloud_ - Automatically detects all the zones across the homes and systems in your cloud account. Climate Entities created for each zone. The integration creates internal unique_ids using the Cloud GUID of your S30 plus the zone index (0,1,2,3).
 
-_Local_ - Automstically detects all the zones in the S30 it is connected to. Climate Entities created for each zone. The integration creates internal unique_ids using the Serial Number of your S30 plus the zone index (0,1,2,3).
+_Local_ - Automatically detects all the zones in the S30 it is connected to. Climate Entities created for each zone. The integration creates internal unique_ids using the Serial Number of your S30 plus the zone index (0,1,2,3).
 
 Entities are attached to the corresponding S30 Device and have default names (which you can change in Home Assistant)
 
@@ -140,7 +141,7 @@ System name is the name you gave to your S30. By default Lennox names the Zones 
 
 ### Supported operations
 
-**HVAC_MODE** supports **off**, **cool**, **heat** or **heat_cool** mode. The specific modes available depend on you equipemnt. For example an AC does not support heat, hence the heat and heat_cool modes will not be available.
+**HVAC_MODE** supports **off**, **cool**, **heat** or **heat_cool** mode. The specific modes available depend on you equipment. For example an AC does not support heat, hence the heat and heat_cool modes will not be available.
 
 **FAN_MODE** may be set to **auto**, **on**, **circulate**.
 
@@ -150,7 +151,9 @@ System name is the name you gave to your S30. By default Lennox names the Zones 
 
 When you are running a schedule; changes to the temperature or fan create a temporary schedule override (the Mobile APP does the same thing). The override will automatically end at the end of the Next Period (e.g. at the time of your next schedule period.) To cancel the override, there is a preset called **Cancel Hold**. Invoking this preset will remove the hold and re-enable the underlying schedule.
 
-Away Mode. The **Away** preset will put the S30 system into Away Mode and the **cancel away mode** preset will return the S30 system to whatever state it was in prior to putting it into away mode. This works the same as if you pressed the away / cancel away icon on the S30 panel.
+Away Mode. The **Away** preset will put the S30 system into Manual Away Mode. You could also use the manual away mode switch to do this. Works the same as if you pressed the away button on the S30 Panel
+
+Cancel Manual Away Mode or Smart Away Mode. The **cancel away mode** preset will cancel the active away mode (manual or smart) and return the S30 system to whatever state it was in prior to putting it into away mode. This works the same as if you pressed the cancel away icon on the S30 panel.
 
 **Emergency Heat** - Lennox systems that have a heat pump and an auxiliary furnace, have an additional HVAC_MODE to run just the auxiliary furnace. In the S30 App this is shown as Emergency Heat. Home Assistant **does not** allow this mode directly - instead Home Assistant provides support for turning aux_heat on and off - independent of the HVAC_MODE. The integration has the following behavior:
 
@@ -169,12 +172,12 @@ The integration provides all of the standard climate attributes, including
 4. Active setpoints - dependent on the HVAC_MODE. For example, in Cool Mode the Cool Setpoint is shown, but not the Heat Setpoint.
 5. Active Preset
 
-In additon the following extra attributes are provided, to allow for a more detailed information on the current zone operation.
+In addition the following extra attributes are provided, to allow for a more detailed information on the current zone operation.
 
 | Attribute Name    | Description                                                                                                                                                                                     |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | allergenDefender  | Indicates if this is enabled on the zone                                                                                                                                                        |
-| aux               | Auxiliary Heating is On when True, off when False. Typicslly this mesns the hest pump is dissbled and the furnace is running instead.                                                           |
+| aux               | Auxiliary Heating is On when True, off when False. Typically this means the hest pump is disabled and the furnace is running instead.                                                           |
 | balancePoint      | This is related to heatpump lockout, details / values are not well known yet - if you know let us know!                                                                                         |
 | coolCoast         | This will only appear in non-zoning systems and it indicates the system is set to a single setpoint mode, the system was in heating mode and has turned off to coast to the desired temperature |
 | damper            | Position of damper - range 0-100. Observationally values are either 0 or 100; where 100 = damper open.                                                                                          |
@@ -182,24 +185,24 @@ In additon the following extra attributes are provided, to allow for a more deta
 | demand            | CFM of air demand for the zone. Thanks @blyons16 for getting this information from his installers                                                                                               |
 | fan               | Indicates if the fan is currently running. Note: this is true only when the fan is running and there is no active HVAC action (cooling, heating, etc.)                                          |
 | heatCoast         | This will only appear in non-zoning systems and it indicates the system is set to a single setpoint mode, the system was in heating mode and has turned off to coast to the desired temperature |
-| humidityOperation | Current active humidty operation - Drying or humidfying                                                                                                                                         |
+| humidityOperation | Current active humidity operation - Drying or humidifying                                                                                                                                       |
 | ssr               | Not known what this attribute indicates. If you know let us know!                                                                                                                               |
-| tempOperation     | Current acvtive temperatue operation heating or cooling                                                                                                                                         |
+| tempOperation     | Current active temperature operation heating or cooling                                                                                                                                         |
 | ventilation       | Indicates if external ventilation is currently active on this zone                                                                                                                              |
 
-## lennoxs30.state or lennoxs30.conn\_\<hostname\> or lennoxs30.\_<redacted email_addess\>
+## lennoxs30.state or lennoxs30.conn\_\<hostname\> or lennoxs30.\_<redacted email_address\>
 
 These entities is automatically created for each integration instance and can be used to track the state and health of the Cloud or Local connection to the S30. When using multiple LAN connections, the
-first host in the list will use **lennoxs30.state** for backwards compatibility. Additional local connections will use a naming convention of **lennoxs30.conn\_<hostname>**. Cloud connections wil use lennoxs30.\_<redacted email_addess\>
+first host in the list will use **lennoxs30.state** for backwards compatibility. Additional local connections will use a naming convention of **lennoxs30.conn\_<hostname>**. Cloud connections wil use lennoxs30.\_<redacted email_address\>
 
-| State            | Description                                                                                                |
-| ---------------- | ---------------------------------------------------------------------------------------------------------- |
-| Connected        | API is connected. This is the desired state                                                                |
-| Connecting       | API is trying to connect                                                                                   |
-| Disconnected     | API has failed to connect and will not try again. Please raise an issue if you encounter this state        |
-| Login Failed     | The login failued due to bad email/password combination. Please correct credentials and reload integration |
-| Waiting to Retry | The API was unable to connect or lost connection and is waiting to attempt a retry                         |
-| Failed           | The API failed. Please raise an issue if you encounter this state                                          |
+| State            | Description                                                                                               |
+| ---------------- | --------------------------------------------------------------------------------------------------------- |
+| Connected        | API is connected. This is the desired state                                                               |
+| Connecting       | API is trying to connect                                                                                  |
+| Disconnected     | API has failed to connect and will not try again. Please raise an issue if you encounter this state       |
+| Login Failed     | The login failed due to bad email/password combination. Please correct credentials and reload integration |
+| Waiting to Retry | The API was unable to connect or lost connection and is waiting to attempt a retry                        |
+| Failed           | The API failed. Please raise an issue if you encounter this state                                         |
 
 The entity also has a set of attributes to provide diagnostic data:
 
@@ -207,15 +210,15 @@ The entity also has a set of attributes to provide diagnostic data:
 | ------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | message_count       | int      | number of messages received from Lennox Cloud                                                                                                                                                                                                                           |
 | send_count          | int      | number of messages sent                                                                                                                                                                                                                                                 |
-| receive_count       | int      | number of queries to recieve new messages. Most queries return no messages                                                                                                                                                                                              |
+| receive_count       | int      | number of queries to receive new messages. Most queries return no messages                                                                                                                                                                                              |
 | bytes_in            | int      | number of bytes received                                                                                                                                                                                                                                                |
 | bytes_out           | int      | number of bytes sent                                                                                                                                                                                                                                                    |
 | error_count         | int      | number of errors                                                                                                                                                                                                                                                        |
-| exceptions          | int      | number of network exceptions that have occured                                                                                                                                                                                                                          |
+| exceptions          | int      | number of network exceptions that have occurred                                                                                                                                                                                                                         |
 | http_2xx            | int      | number of HTTP responses received between 200-299. These are good responses                                                                                                                                                                                             |
 | http_4xx            | int      | number of HTTP responses received between 400-499. These usually indicate a problem with authorization                                                                                                                                                                  |
 | http_5xx            | int      | number of HTTP responses received between 500-599. These indicate a problem with the Cloud or S30. Seeing a few of these a day is normal                                                                                                                                |
-| last_receive_time   | DateTime | Time of last succesful receive. Should not be more than SCAN_INTERVAL seconds plus few seconds plus the metric update interval (90 seconds). In other words is this time is more than 5 minutes ago using default SCAN_INTERVAL something is wrong.                     |
+| last_receive_time   | DateTime | Time of last successful receive. Should not be more than SCAN_INTERVAL seconds plus few seconds plus the metric update interval (90 seconds). In other words is this time is more than 5 minutes ago using default SCAN_INTERVAL something is wrong.                    |
 | last_error_time     | DateTime | Time of the last error response                                                                                                                                                                                                                                         |
 | last_reconnect_time | DateTime | Time of the last reconnect or the time of the initial connect                                                                                                                                                                                                           |
 | last_message_time   | DateTime | Time of the last message from Lennox Cloud. How often messages are received is based on how often data is changing in the thermostat. For example, a temperature change, a setpoint change will cause a message to be sent. If nothing is changing nothing will be sent |
@@ -226,7 +229,7 @@ The entity also has a set of attributes to provide diagnostic data:
 
 ## sensor for Zone Temperature and Humidity
 
-When the **create_sensors** configuration parameter is set, humidity and temperarture sensors are created for each zone. This is the default for new configurations. These sensors are attached to the Thermostat Device.
+When the **create_sensors** configuration parameter is set, humidity and temperature sensors are created for each zone. This is the default for new configurations. These sensors are attached to the Thermostat Device.
 
 sensor.<system_name>\_<zone_name>\_temperature
 
@@ -269,6 +272,18 @@ switch.<system_name>\_\_allergen_defender
 
 The switch will reflect the current state of the allergen defender mode and will allow turning the mode on or off
 
+### manual away mode
+
+This switch reports the current state of manual away mode and allows turning manual away mode on or off.
+
+switch.<system_name>\_manual_away_mode
+
+### smart away enabled
+
+This switch enables or disables smart away on the S30. This switch **does not** put the system into away mode. This switch enables the S30 to perform it's smart away detection of your mobile devices. To properly setup Smart Away you will need to use the Lennox Mobile App. Once smart away is setup, this allow you to turn the detection on or off.
+
+switch.<system_name>\_manual_away_mode
+
 ### ventilation
 
 If your system has an external outdoor air damper a switch will be created.
@@ -278,21 +293,52 @@ switch.<system_name>\_ventilation
 The switch will reflect the current state of the ventilation damper and will allow turning the mode on or off.  
 The switch has the following attributes:
 
-| Attribute               | Type | Description                                                              |
-| ----------------------- | ---- | ------------------------------------------------------------------------ |
-| ventilationRemainigTime | int  | number of minutes remaining in ventilation action                        |
-| ventilatingUntilTime    | int  | integer timestamp of the end time of the ventilation action              |
-| diagVentilationRuntime  | int  | total number of minutes the system has ventilated for over it's lifetime |
+| Attribute                | Type | Description                                                              |
+| ------------------------ | ---- | ------------------------------------------------------------------------ |
+| ventilationRemainingTime | int  | number of minutes remaining in ventilation action                        |
+| ventilatingUntilTime     | int  | integer timestamp of the end time of the ventilation action              |
+| diagVentilationRuntime   | int  | total number of minutes the system has ventilated for over it's lifetime |
+
+## Binary Sensors
+
+### home state
+
+The home state binary sensor reports the current away mode of the S30. A value of 'on' indicates the system is in home mode. A value of 'off' indicates the system is in away mode. This sensor used the "presence" device class, so in Lovelace you will see the value of 'Home' or 'Away'.
+
+binary_sensor.<system_name>\_home_state
+
+The S30 has three setpoint states that are possible - Home, Transition and Away. For this binary sensor the Transition and Away states are reported as Away. The detailed information
+is available within attributes of the binary sensor.
+
+| Attribute                 | Type    | Description                                                                   |
+| ------------------------- | ------- | ----------------------------------------------------------------------------- |
+| manual_away               | boolean | True if manual away is turned on                                              |
+| smart_away                | boolean | True if smart away has turned on away mode                                    |
+| smart_away_enabled        | boolean | True is smart away is enabled                                                 |
+| smart_away_state          | string  | State of smart away. See table below for values                               |
+| smart_away_enabled        | boolean | True is smart away is enabled                                                 |
+| smart_away_reset          | boolean | True if smart away has been reset, value may be transient                     |
+| smart_away_cancel         | boolean | True if smart away has been cancelled, value may be transient                 |
+| smart_away_setpoint_state | string  | Current setpoint state - "home", "transition", "away" are the observed values |
+
+Smart Away State Values
+
+| Value             | Type                                                                                                     |
+| ----------------- | -------------------------------------------------------------------------------------------------------- |
+| enabled cancelled | Indicates the system was in smart away and it was cancelled from either the app, panel or home assistant |
+| enabled active    | Smart away detection is enabled, and smart away has determined you are away                              |
+| enabled inactive  | Smart away detection is enabled, and smart away has determined you are home                              |
+| disabled          | Smart away is disabled                                                                                   |
 
 ## Number
 
 ### diagnostic level
 
-**ALPHA** When the power inverter option is enable, a Number entity is created to allow setting and reporting on the active diagnostic level in the S30. A value of zero indicared diagnostics is disabled. Values of 1 or 2 will cause the inverter power to be sent. Other values are invalid. The name of the entity is:
+**ALPHA** When the power inverter option is enable, a Number entity is created to allow setting and reporting on the active diagnostic level in the S30. A value of zero indicates diagnostics is disabled. Values of 1 or 2 will cause the inverter power to be sent. Other values are invalid. The name of the entity is:
 
 number.<system_name>\_diagnostic_level
 
-Note: This capability in in _Alpha_ Mode. When enabled the S30 sends much more information. If you are using their IOS / Android App - this may impact the performance. It is not recommended to be toggling this mode frequently. Early on there were reports of the S30 rebooting that may have been caused by this - but it has not reproduced. If you are using this feature, you may want to monitor the lennoxS30.state sysuptime attribute. This value will reset to zero when the S30 reboots. The integration will log a warning if this is detected. Please report on your findings - we want to know if its working or not workig for you!
+Note: This capability in in _Alpha_ Mode. When enabled the S30 sends much more information. If you are using their IOS / Android App - this may impact the performance. It is not recommended to be toggling this mode frequently. Early on there were reports of the S30 rebooting that may have been caused by this - but it has not reproduced. If you are using this feature, you may want to monitor the lennoxS30.state sysuptime attribute. This value will reset to zero when the S30 reboots. The integration will log a warning if this is detected. Please report on your findings - we want to know if its working or not working for you!
 
 # Reporting Bugs
 
@@ -310,25 +356,25 @@ logger:
 
 ## A note on Debug Log Files
 
-The Lennox configuration that comes back from the API contains every configuration parameter of your system - including Personally Identifiable Information. The system by default redacts this information in the log files. Stil the recommendation is not to publicly post these. If we need them to debug an issue we can use email.
+The Lennox configuration that comes back from the API contains every configuration parameter of your system - including Personally Identifiable Information. The system by default redacts this information in the log files. Still the recommendation is not to publicly post these. If we need them to debug an issue we can use email.
 
 # Detailed Configuration Parameters
 
-This section documents the detailed configuration paramaters, that are editable through the UI. This configuration is stored in the config/.storage/core_config_entries file. Editing this file is not recommended.
+This section documents the detailed configuration parameters, that are editable through the UI. This configuration is stored in the config/.storage/core_config_entries file. Editing this file is not recommended.
 
 | Name                     | Type    | Requirement | Default            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | ------------------------ | ------- | ----------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| scan_interval            | int     | optional    | 15                 | Scan interval to check for cloud messages in seconds. 15 seconds is recommended for cloud connections. For local connections this sbould not be set unless instructed                                                                                                                                                                                                                                                                                                                                                              |
+| scan_interval            | int     | optional    | 15                 | Scan interval to check for cloud messages in seconds. 15 seconds is recommended for cloud connections. For local connections this should not be set unless instructed                                                                                                                                                                                                                                                                                                                                                              |
 | allergen_defender_switch | bool    | optional    | false              | When true creates a switch entity to allow control of allergenDefender mode                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | fast_scan_interval       | float   | optional    | 0.75               | After issuing a command (setpoint change, hvac mode change, etc.) The system goes into a fast scan mode, in order to make the UI more responsive to commands                                                                                                                                                                                                                                                                                                                                                                       |
 | init_wait_time           | int     | optional    | 30                 | Amount of time to wait for configuration to arrive from Lennox during integration startup. Increase this value if you see initialization timeouts                                                                                                                                                                                                                                                                                                                                                                                  |
 | app_id                   | string  | optional    | uniquely generated | Specify the unique application id to use. For Cloud connections, Lennox is very particular - please use this string - mapp0793723676444670468270xx - and replace xx with a value from 00 - 99. Note that each instance of your integration (e.g. prod system, test system) must use a different value for xx. For local connections use a string like ha_dev or ha_prod - must be unique for each connection                                                                                                                       |
 | create_sensors           | bool    | optional    | false              | Creates temperature and humidity sensors for each zone                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | create_inverter_power    | bool    | optional    | false              | Creates a sensor representing the inverter power usage. This requires configuring the Lennox LCC diagnostic mode to be 1 or 2, as opposed to the default value of 0. Use the number.diagnostic_level entity to set this,.                                                                                                                                                                                                                                                                                                          |
-| protocol                 | string  | optional    | https              | Selects the protocol to use. The only reason to use this is when developing using the S30 simluator, in which case this should be set to HTTP                                                                                                                                                                                                                                                                                                                                                                                      |
+| protocol                 | string  | optional    | https              | Selects the protocol to use. The only reason to use this is when developing using the S30 simulator, in which case this should be set to HTTP                                                                                                                                                                                                                                                                                                                                                                                      |
 | message_debug_logging    | boolean | optional    | True               | When True messages are logged when debug is enabled. Setting to False omits the message from the debug log file.                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | log_messages_to_file     | string  | optional    |                    | When set all S30 messages for this connection will the logged to the specified file. If no path is specified, the file will appear on the home asssistant config directory - the same place the home_assistant.log file is. If you want the fie to be elsewhere specific a full path or relative path to the home assistant root directory. Messages will be logged regardless of debug settings. This provides an easy way to submit the message logs without having to submit all the stuff in the full home assistant log file. |
-| pii_in_message_logs      | boolean | optional    | False              | When set to False personal information - email, passords, street addresses, etc. are redacted from the log files. False is the default and the recommended setting for submitting logs. This parameter exists in the unlikely event this information is needed in troubleshooting.                                                                                                                                                                                                                                                 |
+| pii_in_message_logs      | boolean | optional    | False              | When set to False personal information - email, passwords, street addresses, etc. are redacted from the log files. False is the default and the recommended setting for submitting logs. This parameter exists in the unlikely event this information is needed in troubleshooting.                                                                                                                                                                                                                                                |
 
 # Migration
 
@@ -336,7 +382,7 @@ This section documents the detailed configuration paramaters, that are editable 
 
 ### Migration from 0.1.3 to 0.2.0
 
-In Release 0.2.0 configuration is moved from configuratiom.yaml to the internal home asssistant configuration repository. On startup of 0.2.0 (or later releases), the YAML configuration will be migrated to the repository. After HA starts please check your entities to verify they are working. Once verified remove the lennoxs30 configuration from configuration.yaml. All of your entities should be preserved and the migration should be seamless.
+In Release 0.2.0 configuration is moved from configuration.yaml to the internal home assistant configuration repository. On startup of 0.2.0 (or later releases), the YAML configuration will be migrated to the repository. After HA starts please check your entities to verify they are working. Once verified remove the lennoxs30 configuration from configuration.yaml. All of your entities should be preserved and the migration should be seamless.
 
 ### Migration from <0.1.3 to 0.2.0
 
@@ -359,7 +405,7 @@ The simplest approach is to edit the configuration.yaml in 0.1.3 and add the ip_
 When switching from Cloud to Local - new entities are created in Home Assistant. Perform the following steps after restarting:
 
 - Go into the list of entities and delete the old entities (write down their names if needed)
-- Remame the new entities using the old entity's entity ids.
+- Rename the new entities using the old entity's entity ids.
 
 ### Cloud to Local (have upgraded to 0.2.0)
 
@@ -367,7 +413,7 @@ Use Case: You have the integration configured to use the cloud and you want to g
 Current State: You are on 0.2.0 or greater.
 
 - Go into Configuration / Integrations and Delete the cloud integration
-- Add a new integration instace for the local connection.
+- Add a new integration instance for the local connection.
 
 ## Migrate to HACS from Manual Installation
 
@@ -406,7 +452,7 @@ The local connection uses HTTPS to Port 443 outgoing to the S30.
 
 The cloud connection using HTTPS to Port 443 outgoing to the Lennox Cloud.
 
-There are no incomimg connections.
+There are no incoming connections.
 
 # Enhancement Requests
 

--- a/custom_components/lennoxs30/__init__.py
+++ b/custom_components/lennoxs30/__init__.py
@@ -51,8 +51,7 @@ from typing import Any
 
 DOMAIN = LENNOX_DOMAIN
 DOMAIN_STATE = "lennoxs30.state"
-PLATFORMS = ["sensor", "climate", "switch", "number"]
-
+PLATFORMS = ["sensor", "climate", "switch", "number", "binary_sensor"]
 
 DS_CONNECTING = "Connecting"
 DS_DISCONNECTED = "Disconnected"

--- a/custom_components/lennoxs30/binary_sensor.py
+++ b/custom_components/lennoxs30/binary_sensor.py
@@ -39,8 +39,8 @@ async def async_setup_entry(
         )
         return True
     else:
-        _LOGGER.info(
-            f"binary_sensor:async_setup_platform exit - no system outdoor temperatures found"
+        _LOGGER.warning(
+            f"binary_sensor:async_setup_platform exit - no S30HomeStateBinarySensor found - this should not happen"
         )
         return False
 

--- a/custom_components/lennoxs30/binary_sensor.py
+++ b/custom_components/lennoxs30/binary_sensor.py
@@ -1,0 +1,116 @@
+"""Support for Lennoxs30 outdoor temperature sensor"""
+from typing import Any
+from .const import MANAGER
+from . import Manager
+from homeassistant.core import HomeAssistant
+import logging
+from lennoxs30api import lennox_system
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity import DeviceInfo
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "lennoxs30"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> bool:
+
+    sensor_list = []
+
+    manager: Manager = hass.data[DOMAIN][entry.unique_id][MANAGER]
+    for system in manager._api.getSystems():
+        _LOGGER.info(
+            f"Create S30HomeStateBinarySensor binary_sensor system [{system.sysId}]"
+        )
+        sensor = S30HomeStateBinarySensor(hass, manager, system)
+        sensor_list.append(sensor)
+
+    if len(sensor_list) != 0:
+        async_add_entities(sensor_list, True)
+        _LOGGER.debug(
+            f"binary_sensor:async_setup_platform exit - created [{len(sensor_list)}] entitites"
+        )
+        return True
+    else:
+        _LOGGER.info(
+            f"binary_sensor:async_setup_platform exit - no system outdoor temperatures found"
+        )
+        return False
+
+
+class S30HomeStateBinarySensor(BinarySensorEntity):
+    def __init__(self, hass: HomeAssistant, manager: Manager, system: lennox_system):
+        self._hass = hass
+        self._manager = manager
+        self._system = system
+        self._system.registerOnUpdateCallback(
+            self.update_callback,
+            [
+                "manualAwayMode",
+                "sa_enabled",
+                "sa_state",
+                "sa_reset",
+                "sa_cancel",
+                "sa_setpointState",
+            ],
+        )
+        self._myname = self._system.name + "_home_state"
+
+    def update_callback(self):
+        _LOGGER.debug(
+            f"update_callback S30HomeStateBinarySensor myname [{self._myname}]"
+        )
+        self.schedule_update_ha_state()
+
+    @property
+    def unique_id(self) -> str:
+        # HA fails with dashes in IDs
+        return (self._system.unique_id() + "_HS").replace("-", "")
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        attrs: dict[str, Any] = {}
+        attrs["manual_away"] = self._system.get_manual_away_mode()
+        attrs["smart_away"] = self._system.get_smart_away_mode()
+        attrs["smart_away_enabled"] = self._system.sa_enabled
+        attrs["smart_away_state"] = self._system.sa_state
+        attrs["smart_away_reset"] = self._system.sa_reset
+        attrs["smart_away_cancel"] = self._system.sa_cancel
+        attrs["smart_away_setpoint_state"] = self._system.sa_setpointState
+        return attrs
+
+    def update(self):
+        """Update data from the thermostat API."""
+        return True
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        return self._myname
+
+    @property
+    def is_on(self):
+        return self._system.get_away_mode() == False
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return {
+            "identifiers": {(DOMAIN, self._system.unique_id())},
+        }
+
+    @property
+    def device_class(self):
+        return "presence"

--- a/custom_components/lennoxs30/binary_sensor.py
+++ b/custom_components/lennoxs30/binary_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import DeviceInfo
 
 from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_PRESENCE,
     BinarySensorEntity,
 )
 
@@ -113,4 +114,4 @@ class S30HomeStateBinarySensor(BinarySensorEntity):
 
     @property
     def device_class(self):
-        return "presence"
+        return DEVICE_CLASS_PRESENCE

--- a/custom_components/lennoxs30/climate.py
+++ b/custom_components/lennoxs30/climate.py
@@ -512,11 +512,6 @@ class S30Climate(ClimateEntity):
             _LOGGER.error("async_set_preset_mode error:" + str(e))
 
     @property
-    def is_away_mode_on(self):
-        """Return the current away mode status."""
-        return self._system.get_away_mode()
-
-    @property
     def fan_mode(self):
         """Return the current fan mode."""
         return self._zone.getFanMode()

--- a/custom_components/lennoxs30/manifest.json
+++ b/custom_components/lennoxs30/manifest.json
@@ -1,11 +1,11 @@
 {
     "domain": "lennoxs30",
     "name": "Lennox S30/E30",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "documentation": "https://github.com/PeteRager/lennoxs30/blob/master/README.MD",
     "issuetracker" : "https://github.com/PeteRager/lennoxs30/issues",
     "dependencies": [],
-    "requirements": ["lennoxs30api==0.1.4"],
+    "requirements": ["lennoxs30api==0.1.5"],
     "codeowners": ["@PeteRager"],
     "iot_class": "local_polling",
 	"config_flow": true

--- a/custom_components/lennoxs30/number.py
+++ b/custom_components/lennoxs30/number.py
@@ -38,7 +38,7 @@ async def async_setup_entry(
         or manager._create_inverter_power == False
     ):
         _LOGGER.debug(
-            "async_setup_entry - not cresting diagnosrtic level number because inverter power not enabled"
+            "async_setup_entry - not creating diagnostic level number because inverter power not enabled"
         )
         return
     for system in manager._api.getSystems():

--- a/custom_components/lennoxs30/sensor.py
+++ b/custom_components/lennoxs30/sensor.py
@@ -1,7 +1,6 @@
 """Support for Lennoxs30 outdoor temperature sensor"""
 from .const import MANAGER
 from homeassistant.const import (
-    CONF_NAME,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
@@ -13,7 +12,6 @@ from homeassistant.const import (
 from . import Manager
 from homeassistant.core import HomeAssistant
 import logging
-from homeassistant.helpers.entity import Entity
 from lennoxs30api import lennox_system, lennox_zone
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -22,7 +20,6 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
     SensorEntity,
-    PLATFORM_SCHEMA,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -68,12 +65,12 @@ async def async_setup_entry(
     if len(sensor_list) != 0:
         async_add_entities(sensor_list, True)
         _LOGGER.debug(
-            f"climate:async_setup_platform exit - created [{len(sensor_list)}] entitites"
+            f"sensor:async_setup_platform exit - created [{len(sensor_list)}] entitites"
         )
         return True
     else:
         _LOGGER.info(
-            f"climate:async_setup_platform exit - no system outdoor temperatures found"
+            f"sensor:async_setup_platform exit - no system outdoor temperatures found"
         )
         return False
 

--- a/tests/test_away_mode_switches.py
+++ b/tests/test_away_mode_switches.py
@@ -1,0 +1,111 @@
+from lennoxs30api.s30api_async import (
+    LENNOX_SA_STATE_DISABLED,
+    LENNOX_SA_SETPOINT_STATE_HOME,
+    LENNOX_SA_SETPOINT_STATE_AWAY,
+    LENNOX_SA_STATE_ENABLED_ACTIVE,
+    lennox_system,
+)
+from custom_components.lennoxs30 import (
+    DOMAIN,
+    Manager,
+)
+
+from custom_components.lennoxs30.const import LENNOX_DOMAIN
+
+import pytest
+from custom_components.lennoxs30.switch import (
+    S30ManualAwayModeSwitch,
+    S30SmartAwayEnableSwitch,
+)
+
+from unittest.mock import patch
+
+
+@pytest.mark.asyncio
+async def test_manual_away_mode_switch_subscription(hass, manager: Manager, caplog):
+    system: lennox_system = manager._api._systemList[0]
+    manager._is_metric = False
+    c = S30ManualAwayModeSwitch(hass, manager, system)
+
+    with patch.object(c, "schedule_update_ha_state") as update_callback:
+        set = {"manual_away_mode": not system.manualAwayMode}
+        system.attr_updater(set, "manual_away_mode", "manualAwayMode")
+        system.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_manual_away_mode_switch(hass, manager: Manager, caplog):
+    system: lennox_system = manager._api._systemList[0]
+    manager._is_metric = False
+    c = S30ManualAwayModeSwitch(hass, manager, system)
+
+    assert c.unique_id == (system.unique_id() + "_SW_MA").replace("-", "")
+    assert c.name == system.name + "_manual_away_mode"
+    identifiers = c.device_info["identifiers"]
+    for x in identifiers:
+        assert x[0] == LENNOX_DOMAIN
+        assert x[1] == system.unique_id()
+
+    system.manualAwayMode = False
+    assert c.is_on == False
+
+    system.manualAwayMode = True
+    assert c.is_on == True
+
+    with patch.object(system, "set_manual_away_mode") as set_manual_away:
+        await c.async_turn_on()
+        assert set_manual_away.call_count == 1
+        arg0 = set_manual_away.await_args[0][0]
+        assert arg0 == True
+
+    with patch.object(system, "set_manual_away_mode") as set_manual_away:
+        await c.async_turn_off()
+        assert set_manual_away.call_count == 1
+        arg0 = set_manual_away.await_args[0][0]
+        assert arg0 == False
+
+
+@pytest.mark.asyncio
+async def test_smart_away_enabled_switch_subscription(hass, manager: Manager, caplog):
+    system: lennox_system = manager._api._systemList[0]
+    manager._is_metric = False
+    c = S30SmartAwayEnableSwitch(hass, manager, system)
+
+    with patch.object(c, "schedule_update_ha_state") as update_callback:
+        set = {"sa_enabled": not system.sa_enabled}
+        system.attr_updater(set, "sa_enabled", "sa_enabled")
+        system.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_smart_away_enabled_switch(hass, manager: Manager, caplog):
+    system: lennox_system = manager._api._systemList[0]
+    manager._is_metric = False
+    c = S30SmartAwayEnableSwitch(hass, manager, system)
+
+    assert c.unique_id == (system.unique_id() + "_SW_SAE").replace("-", "")
+    assert c.name == system.name + "_smart_away_enable"
+    identifiers = c.device_info["identifiers"]
+    for x in identifiers:
+        assert x[0] == LENNOX_DOMAIN
+        assert x[1] == system.unique_id()
+
+    system.sa_enabled = False
+    assert c.is_on == False
+
+    system.sa_enabled = True
+    assert c.is_on == True
+
+    with patch.object(system, "enable_smart_away") as enable_smart_away:
+        await c.async_turn_on()
+        assert enable_smart_away.call_count == 1
+        arg0 = enable_smart_away.await_args[0][0]
+        assert arg0 == True
+
+    with patch.object(system, "enable_smart_away") as enable_smart_away:
+        await c.async_turn_off()
+        assert enable_smart_away.call_count == 1
+        arg0 = enable_smart_away.await_args[0][0]
+        assert arg0 == False

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,18 +1,16 @@
-from re import S
-from turtle import up
-
 from lennoxs30api.s30api_async import (
     LENNOX_HVAC_COOL,
     LENNOX_HVAC_HEAT,
     LENNOX_HVAC_HEAT_COOL,
     LENNOX_HVAC_OFF,
-    LENNOX_SA_STATE_AWAY,
     LENNOX_SA_STATE_DISABLED,
+    LENNOX_SA_SETPOINT_STATE_AWAY,
+    LENNOX_SA_SETPOINT_STATE_TRANSITION,
+    LENNOX_SA_SETPOINT_STATE_HOME,
     lennox_system,
     lennox_zone,
 )
 from custom_components.lennoxs30 import (
-    DOMAIN,
     Manager,
 )
 import pytest
@@ -151,7 +149,7 @@ async def test_climate_preset_mode(hass, manager: Manager, caplog):
     system.sa_enabled = True
     assert zone.scheduleId == zone.getManualModeScheduleId()
     assert c.preset_mode == PRESET_NONE
-    system.sa_state = LENNOX_SA_STATE_AWAY
+    system.sa_setpointState = LENNOX_SA_SETPOINT_STATE_AWAY
     assert c.preset_mode == PRESET_AWAY
     system.sa_state = LENNOX_SA_STATE_DISABLED
     assert c.preset_mode == PRESET_NONE
@@ -179,7 +177,7 @@ async def test_set_preset_mode(hass, manager: Manager, caplog):
             assert cancel_smart_away.call_count == 0
 
     system.sa_enabled = True
-    system.sa_state = LENNOX_SA_STATE_AWAY
+    system.sa_setpointState = LENNOX_SA_SETPOINT_STATE_AWAY
     assert system.get_manual_away_mode() == True
     assert system.get_smart_away_mode() == True
     with patch.object(system, "set_manual_away_mode") as set_manual_away:
@@ -192,7 +190,7 @@ async def test_set_preset_mode(hass, manager: Manager, caplog):
 
     system.manualAwayMode = False
     system.sa_enabled = True
-    system.sa_state = LENNOX_SA_STATE_AWAY
+    system.sa_setpoint_state = LENNOX_SA_SETPOINT_STATE_AWAY
     assert system.get_manual_away_mode() == False
     assert system.get_smart_away_mode() == True
     with patch.object(system, "set_manual_away_mode") as set_manual_away:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,10 +1,13 @@
 from re import S
+from turtle import up
 
 from lennoxs30api.s30api_async import (
     LENNOX_HVAC_COOL,
     LENNOX_HVAC_HEAT,
     LENNOX_HVAC_HEAT_COOL,
     LENNOX_HVAC_OFF,
+    LENNOX_SA_STATE_AWAY,
+    LENNOX_SA_STATE_DISABLED,
     lennox_system,
     lennox_zone,
 )
@@ -14,8 +17,21 @@ from custom_components.lennoxs30 import (
 )
 import pytest
 import logging
+import asyncio
 
-from custom_components.lennoxs30.climate import S30Climate
+from custom_components.lennoxs30.climate import (
+    PRESET_CANCEL_AWAY_MODE,
+    PRESET_CANCEL_HOLD,
+    PRESET_SCHEDULE_OVERRIDE,
+    S30Climate,
+)
+
+from unittest.mock import patch
+
+from homeassistant.components.climate.const import (
+    PRESET_AWAY,
+    PRESET_NONE,
+)
 
 
 @pytest.mark.asyncio
@@ -87,3 +103,153 @@ async def test_climate_min_max_f(hass, manager: Manager, caplog):
         assert c.min_temp == 44.6
         assert c.max_temp == 95
         assert len(caplog.records) == 2
+
+
+@pytest.mark.asyncio
+async def test_climate_system_subscription(hass, manager: Manager, caplog):
+    system: lennox_system = manager._api._systemList[0]
+    manager._is_metric = False
+    zone: lennox_zone = system._zoneList[0]
+    c = S30Climate(hass, manager, system, zone)
+
+    with patch.object(c, "schedule_update_ha_state") as update_callback:
+        set = {
+            "enabled": not system.sa_enabled,
+            "reset": not system.sa_reset,
+            "cancel": not system.sa_cancel,
+            "state": "Cancelled",
+            "setpointState": "a setpoint state",
+        }
+        system.attr_updater(set, "enabled", "sa_enabled")
+        system.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 1
+        system.attr_updater(set, "reset", "sa_reset")
+        system.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 2
+        system.attr_updater(set, "cancel", "sa_cancel")
+        system.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 3
+        system.attr_updater(set, "state", "sa_state")
+        system.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 4
+        system.attr_updater(set, "setpointState", "sa_setpointState")
+        system.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_climate_preset_mode(hass, manager: Manager, caplog):
+    system: lennox_system = manager._api._systemList[0]
+    manager._is_metric = False
+    zone: lennox_zone = system._zoneList[0]
+    c = S30Climate(hass, manager, system, zone)
+    assert system.get_manual_away_mode() == True
+    assert c.preset_mode == PRESET_AWAY
+    assert c.is_away_mode_on == True
+    system.manualAwayMode = False
+    assert zone.scheduleId == zone.getManualModeScheduleId()
+    assert c.preset_mode == PRESET_NONE
+    assert c.is_away_mode_on == False
+    system.sa_enabled = True
+    assert zone.scheduleId == zone.getManualModeScheduleId()
+    assert c.preset_mode == PRESET_NONE
+    assert c.is_away_mode_on == False
+    system.sa_state = LENNOX_SA_STATE_AWAY
+    assert c.preset_mode == PRESET_AWAY
+    assert c.is_away_mode_on == True
+    system.sa_state = LENNOX_SA_STATE_DISABLED
+    assert c.preset_mode == PRESET_NONE
+    assert c.is_away_mode_on == False
+    zone.scheduleId = 2
+    assert c.preset_mode == "winter"
+    zone.overrideActive = True
+    assert c.preset_mode == PRESET_SCHEDULE_OVERRIDE
+
+
+@pytest.mark.asyncio
+async def test_set_preset_mode(hass, manager: Manager, caplog):
+    system: lennox_system = manager._api._systemList[0]
+    manager._is_metric = False
+    zone: lennox_zone = system._zoneList[0]
+    c = S30Climate(hass, manager, system, zone)
+
+    assert system.get_manual_away_mode() == True
+    assert system.get_smart_away_mode() == False
+    with patch.object(system, "set_manual_away_mode") as set_manual_away:
+        with patch.object(system, "cancel_smart_away") as cancel_smart_away:
+            await c.async_set_preset_mode(PRESET_CANCEL_AWAY_MODE)
+            assert set_manual_away.call_count == 1
+            arg0 = set_manual_away.await_args[0][0]
+            assert arg0 == False
+            assert cancel_smart_away.call_count == 0
+
+    system.sa_enabled = True
+    system.sa_state = LENNOX_SA_STATE_AWAY
+    assert system.get_manual_away_mode() == True
+    assert system.get_smart_away_mode() == True
+    with patch.object(system, "set_manual_away_mode") as set_manual_away:
+        with patch.object(system, "cancel_smart_away") as cancel_smart_away:
+            await c.async_set_preset_mode(PRESET_CANCEL_AWAY_MODE)
+            assert set_manual_away.call_count == 1
+            arg0 = set_manual_away.await_args[0][0]
+            assert arg0 == False
+            assert cancel_smart_away.call_count == 1
+
+    system.manualAwayMode = False
+    system.sa_enabled = True
+    system.sa_state = LENNOX_SA_STATE_AWAY
+    assert system.get_manual_away_mode() == False
+    assert system.get_smart_away_mode() == True
+    with patch.object(system, "set_manual_away_mode") as set_manual_away:
+        with patch.object(system, "cancel_smart_away") as cancel_smart_away:
+            await c.async_set_preset_mode(PRESET_CANCEL_AWAY_MODE)
+            assert set_manual_away.call_count == 0
+            assert cancel_smart_away.call_count == 1
+
+    system.manualAwayMode = False
+    system.sa_enabled = False
+    system.sa_state = LENNOX_SA_STATE_DISABLED
+    assert system.get_manual_away_mode() == False
+    assert system.get_smart_away_mode() == False
+    with patch.object(system, "set_manual_away_mode") as set_manual_away:
+        with patch.object(system, "cancel_smart_away") as cancel_smart_away:
+            await c.async_set_preset_mode(PRESET_AWAY)
+            assert set_manual_away.call_count == 1
+            arg0 = set_manual_away.await_args[0][0]
+            assert arg0 == True
+            assert cancel_smart_away.call_count == 0
+
+    system.manualAwayMode = True
+    system.sa_enabled = False
+    system.sa_state = LENNOX_SA_STATE_DISABLED
+    assert system.get_manual_away_mode() == True
+    assert system.get_smart_away_mode() == False
+    with patch.object(system, "set_manual_away_mode") as set_manual_away:
+        with patch.object(zone, "setSchedule") as zone_set_schedule:
+            await c.async_set_preset_mode("winter")
+            assert set_manual_away.call_count == 1
+            arg0 = set_manual_away.await_args[0][0]
+            assert arg0 == False
+            assert zone_set_schedule.call_count == 1
+            arg0 = zone_set_schedule.await_args[0][0]
+            assert arg0 == "winter"
+
+    system.manualAwayMode = False
+    system.sa_enabled = False
+    system.sa_state = LENNOX_SA_STATE_DISABLED
+    assert system.get_manual_away_mode() == False
+    assert system.get_smart_away_mode() == False
+    with patch.object(zone, "setScheduleHold") as zone_set_schedule_hold:
+        await c.async_set_preset_mode(PRESET_CANCEL_HOLD)
+        assert zone_set_schedule_hold.call_count == 1
+        arg0 = zone_set_schedule_hold.await_args[0][0]
+        assert arg0 == False
+
+    system.manualAwayMode = False
+    system.sa_enabled = False
+    system.sa_state = LENNOX_SA_STATE_DISABLED
+    assert system.get_manual_away_mode() == False
+    assert system.get_smart_away_mode() == False
+    with patch.object(zone, "setManualMode") as zone_set_manual_mode:
+        await c.async_set_preset_mode(PRESET_NONE)
+        assert zone_set_manual_mode.call_count == 1

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -145,21 +145,16 @@ async def test_climate_preset_mode(hass, manager: Manager, caplog):
     c = S30Climate(hass, manager, system, zone)
     assert system.get_manual_away_mode() == True
     assert c.preset_mode == PRESET_AWAY
-    assert c.is_away_mode_on == True
     system.manualAwayMode = False
     assert zone.scheduleId == zone.getManualModeScheduleId()
     assert c.preset_mode == PRESET_NONE
-    assert c.is_away_mode_on == False
     system.sa_enabled = True
     assert zone.scheduleId == zone.getManualModeScheduleId()
     assert c.preset_mode == PRESET_NONE
-    assert c.is_away_mode_on == False
     system.sa_state = LENNOX_SA_STATE_AWAY
     assert c.preset_mode == PRESET_AWAY
-    assert c.is_away_mode_on == True
     system.sa_state = LENNOX_SA_STATE_DISABLED
     assert c.preset_mode == PRESET_NONE
-    assert c.is_away_mode_on == False
     zone.scheduleId = 2
     assert c.preset_mode == "winter"
     zone.overrideActive = True

--- a/tests/test_home_state_binary_sensor.py
+++ b/tests/test_home_state_binary_sensor.py
@@ -1,0 +1,110 @@
+from lennoxs30api.s30api_async import (
+    LENNOX_SA_STATE_DISABLED,
+    LENNOX_SA_SETPOINT_STATE_HOME,
+    LENNOX_SA_SETPOINT_STATE_AWAY,
+    LENNOX_SA_STATE_ENABLED_ACTIVE,
+    lennox_system,
+)
+from custom_components.lennoxs30 import (
+    DOMAIN,
+    Manager,
+)
+
+from custom_components.lennoxs30.const import LENNOX_DOMAIN
+
+import pytest
+from custom_components.lennoxs30.binary_sensor import S30HomeStateBinarySensor
+
+from unittest.mock import patch
+
+
+@pytest.mark.asyncio
+async def test_away_mode_subscription(hass, manager: Manager, caplog):
+    system: lennox_system = manager._api._systemList[0]
+    manager._is_metric = False
+    c = S30HomeStateBinarySensor(hass, manager, system)
+
+    with patch.object(c, "schedule_update_ha_state") as update_callback:
+        set = {
+            "enabled": not system.sa_enabled,
+            "reset": not system.sa_reset,
+            "cancel": not system.sa_cancel,
+            "state": "Cancelled",
+            "setpointState": "a setpoint state",
+        }
+        system.attr_updater(set, "enabled", "sa_enabled")
+        system.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 1
+        system.attr_updater(set, "reset", "sa_reset")
+        system.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 2
+        system.attr_updater(set, "cancel", "sa_cancel")
+        system.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 3
+        system.attr_updater(set, "state", "sa_state")
+        system.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 4
+        system.attr_updater(set, "setpointState", "sa_setpointState")
+        system.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_away_mode_value(hass, manager: Manager, caplog):
+    system: lennox_system = manager._api._systemList[0]
+    manager._is_metric = False
+    c = S30HomeStateBinarySensor(hass, manager, system)
+
+    assert c.unique_id == (system.unique_id() + "_HS").replace("-", "")
+    assert c.name == system.name + "_home_state"
+    assert c.device_class == "presence"
+
+    identifiers = c.device_info["identifiers"]
+    for x in identifiers:
+        assert x[0] == LENNOX_DOMAIN
+        assert x[1] == system.unique_id()
+
+    assert c.is_on == False
+    attrs = c.extra_state_attributes
+    assert attrs["manual_away"] == True
+    assert attrs["smart_away"] == False
+    assert attrs["smart_away_enabled"] == False
+    assert attrs["smart_away_state"] == LENNOX_SA_STATE_DISABLED
+    assert attrs["smart_away_reset"] == False
+    assert attrs["smart_away_cancel"] == False
+    assert attrs["smart_away_setpoint_state"] == LENNOX_SA_SETPOINT_STATE_HOME
+
+    system.manualAwayMode = False
+    assert c.is_on == True
+    attrs = c.extra_state_attributes
+    assert attrs["manual_away"] == False
+    assert attrs["smart_away"] == False
+    assert attrs["smart_away_enabled"] == False
+    assert attrs["smart_away_state"] == LENNOX_SA_STATE_DISABLED
+    assert attrs["smart_away_reset"] == False
+    assert attrs["smart_away_cancel"] == False
+    assert attrs["smart_away_setpoint_state"] == LENNOX_SA_SETPOINT_STATE_HOME
+
+    system.sa_enabled = True
+    assert c.is_on == True
+    attrs = c.extra_state_attributes
+    assert attrs["manual_away"] == False
+    assert attrs["smart_away"] == False
+    assert attrs["smart_away_enabled"] == True
+    assert attrs["smart_away_state"] == LENNOX_SA_STATE_DISABLED
+    assert attrs["smart_away_reset"] == False
+    assert attrs["smart_away_cancel"] == False
+    assert attrs["smart_away_setpoint_state"] == LENNOX_SA_SETPOINT_STATE_HOME
+
+    system.sa_enabled = True
+    system.sa_state = LENNOX_SA_STATE_ENABLED_ACTIVE
+    system.sa_setpointState = LENNOX_SA_SETPOINT_STATE_AWAY
+    assert c.is_on == False
+    attrs = c.extra_state_attributes
+    assert attrs["manual_away"] == False
+    assert attrs["smart_away"] == True
+    assert attrs["smart_away_enabled"] == True
+    assert attrs["smart_away_state"] == LENNOX_SA_STATE_ENABLED_ACTIVE
+    assert attrs["smart_away_reset"] == False
+    assert attrs["smart_away_cancel"] == False
+    assert attrs["smart_away_setpoint_state"] == LENNOX_SA_SETPOINT_STATE_AWAY


### PR DESCRIPTION
If Smart Away is on or manual away is on, preset mode for zone will be PRESET_AWAY.

Setting preset to PRESET_CANCEL_AWAY_MODE will cancel smart away and manual away.

Add unit tests