### PR TITLE
Emergency Mode Celsius Null Temperature

### DIFF
--- a/custom_components/lennoxs30/manifest.json
+++ b/custom_components/lennoxs30/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_push",
   "issue_tracker" : "https://github.com/PeteRager/lennoxs30/issues",
   "quality_scale": "platinum",
-  "requirements": ["lennoxs30api==0.2.12"],
-  "version": "2024.1.1"
+  "requirements": ["lennoxs30api==0.2.13"],
+  "version": "2024.1.2"
 }

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1503,6 +1503,21 @@ async def test_climate_set_temperature(hass, manager_mz: Manager, caplog):
                 assert ex is not None
                 assert "System Mode is [off]" in str(ex)
 
+    system.single_setpoint_mode = False
+    zone.systemMode = "off"
+    with patch.object(c, "async_set_hvac_mode") as async_set_hvac_mode:
+        with patch.object(zone, "perform_setpoint") as perform_setpoint:
+            with caplog.at_level(logging.ERROR):
+                caplog.clear()
+                ex: HomeAssistantError = None
+                try:
+                    await c.async_set_temperature(temperature=73)
+                except HomeAssistantError as err:
+                    ex = err
+                assert ex is not None
+                assert "System Mode is [off]" in str(ex)                
+    system.single_setpoint_mode = False
+ 
     zone.systemMode = "cool"
     with patch.object(c, "async_set_hvac_mode") as async_set_hvac_mode:
         with patch.object(zone, "perform_setpoint") as perform_setpoint:


### PR DESCRIPTION
When a lennox system is in emergency mode and using Celsius units a null target temperature is being returned for the zone.  This has been addressed and it now return the high setpoint,

- Fix for #300
- Add additional unit test