### PR TITLE
Fix check for emergency heat

### DIFF
--- a/custom_components/lennoxs30/climate.py
+++ b/custom_components/lennoxs30/climate.py
@@ -214,7 +214,7 @@ class S30Climate(S30BaseEntityMixin, ClimateEntity):
         ):
             mask |= ClimateEntityFeature.TARGET_HUMIDITY
 
-        if self._zone.heatingOption and self._system.has_emergency_heat():
+        if self._zone.emergencyHeatingOption or self._system.has_emergency_heat():
             mask |= ClimateEntityFeature.AUX_HEAT
 
         _LOGGER.debug("climate:supported_features name [%s] support_flags [%d]", self._myname, SUPPORT_FLAGS)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -757,11 +757,23 @@ async def test_climate_supported_features(hass, manager_mz: Manager):
     assert feat & SUPPORT_PRESET_MODE != 0
     assert feat & SUPPORT_FAN_MODE != 0
 
-    c._zone.heatingOption = True
+    c._zone.emergencyHeatingOption = False
     with patch.object(system, "has_emergency_heat") as has_emergency_heat:
         has_emergency_heat.return_value = True
         feat = c.supported_features
         assert feat & SUPPORT_AUX_HEAT != 0
+
+    c._zone.emergencyHeatingOption = True
+    with patch.object(system, "has_emergency_heat") as has_emergency_heat:
+        has_emergency_heat.return_value = False
+        feat = c.supported_features
+        assert feat & SUPPORT_AUX_HEAT != 0
+
+    c._zone.emergencyHeatingOption = False
+    with patch.object(system, "has_emergency_heat") as has_emergency_heat:
+        has_emergency_heat.return_value = False
+        feat = c.supported_features
+        assert feat & SUPPORT_AUX_HEAT == 0
 
     zone1: lennox_zone = system.zone_list[1]
     c1 = S30Climate(hass, manager, system, zone1)


### PR DESCRIPTION
Emergency Heat was being checked by looking at the system configuration to see if the system had a furnace and heat pump. However, the lennox zone configuration has a parameter that indicates if the zone has emergency heat.  The code has been updated to look at that parameter