### PR TITLE
Support metric units for equipment parameters

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,8 +1,9 @@
 {
   "configurations": [
+
       {
           "name": "Python: Debug Tests",
-          "type": "python",
+          "type": "",
           "request": "launch",
           "program": "${file}",
           "purpose": ["debug-test"],
@@ -12,6 +13,17 @@
               "hidden": true, // keep original launch order in 'run and debug' tab
           }
       },
+      {
+        "name": "Debug Tests",
+        "type": "debugpy",
+        "request": "launch",
+        "program": "${file}",
+        "console": "integratedTerminal",
+        "justMyCode": false,
+        "presentation": {
+            "hidden": true, // keep original launch order in 'run and debug' tab
+        }
+    }      
   ],
   "version": "0.2.0"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
   "python.experiments.optOutFrom": ["pythonTestAdapter"],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
+  "debugpy.debugJustMyCode": false,
   "cSpell.words": [
     "ASHRAE",
     "automations",

--- a/custom_components/lennoxs30/number.py
+++ b/custom_components/lennoxs30/number.py
@@ -438,6 +438,7 @@ class TimedVentilationNumber(S30BaseEntityMixin, NumberEntity):
 class EquipmentParameterNumber(S30BaseEntityMixin, NumberEntity):
     """Set timed ventilation."""
 
+    # These parameters are absolute temperatures and will e given a device class.
     absolute_temperature_pids: list[int] = [
         202, 203, 105, 106, 128, 129, 55, 178, 194,
         195, 179, 297, 298, 299, 300, 301, 302, 326, 327, 328

--- a/custom_components/lennoxs30/number.py
+++ b/custom_components/lennoxs30/number.py
@@ -438,7 +438,7 @@ class TimedVentilationNumber(S30BaseEntityMixin, NumberEntity):
 class EquipmentParameterNumber(S30BaseEntityMixin, NumberEntity):
     """Set timed ventilation."""
 
-    # These parameters are absolute temperatures and will e given a device class.
+    # These parameters are absolute temperatures and will be given a device class.
     absolute_temperature_pids: list[int] = [
         202, 203, 105, 106, 128, 129, 55, 178, 194,
         195, 179, 297, 298, 299, 300, 301, 302, 326, 327, 328

--- a/custom_components/lennoxs30/number.py
+++ b/custom_components/lennoxs30/number.py
@@ -464,6 +464,9 @@ class EquipmentParameterNumber(S30BaseEntityMixin, NumberEntity):
             parameter.pid,
             self._myname,
         )
+        self._attr_native_unit_of_measurement = lennox_uom_to_ha_uom(self.parameter.unit)
+        self._attr_device_class = self._get_device_class()
+
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
@@ -533,22 +536,15 @@ class EquipmentParameterNumber(S30BaseEntityMixin, NumberEntity):
                 f"set_native_value unexpected exception, please log issue, [{self._myname}] exception [{ex}]"
             ) from ex
 
-    @property
-    def native_unit_of_measurement(self):
-        return lennox_uom_to_ha_uom(self.parameter.unit)
-    
-    @property
-    def device_class(self):
-        uom = self.native_unit_of_measurement
+
+    def _get_device_class(self)->NumberDeviceClass|None:
+        uom = self._attr_native_unit_of_measurement
         if uom in (UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT):
             # Many of the parameters are temperature offsets, for now we only
             # report absolute temperatures as having the device_class which allows
             # then to be automatically translated to celsius
             if self.parameter.pid in self.absolute_temperature_pids:
                 return NumberDeviceClass.TEMPERATURE
-            return None
-        if uom == UnitOfVolumeFlowRate.CUBIC_FEET_PER_MINUTE:
-            return NumberDeviceClass.VOLUME_FLOW_RATE
         return None
 
 

--- a/custom_components/lennoxs30/number.py
+++ b/custom_components/lennoxs30/number.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     PERCENTAGE,
     UnitOfTemperature,
     UnitOfTime,
-    UnitOfVolumeFlowRate,
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.exceptions import HomeAssistantError

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -38,7 +38,6 @@ from custom_components.lennoxs30 import (
     DS_DISCONNECTED,
     DS_LOGIN_FAILED,
     DS_RETRY_WAIT,
-    PLATFORMS,
     RETRY_INTERVAL_SECONDS,
     Manager,
 )

--- a/tests/test_number_equipment_parameter_number.py
+++ b/tests/test_number_equipment_parameter_number.py
@@ -54,8 +54,26 @@ async def test_equipment_parameter_number_unit_of_measure(hass, manager: Manager
     equipment = system.equipment[0]
     parameter = equipment.parameters[72]
     c = EquipmentParameterNumber(hass, manager, system, equipment, parameter)
+    c.hass = hass
+
+    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+    assert c.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT
     assert c.unit_of_measurement == UnitOfTemperature.FAHRENHEIT
 
+    hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+    assert c.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT
+    assert c.unit_of_measurement == UnitOfTemperature.FAHRENHEIT
+
+    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+    parameter = equipment.parameters[202]
+    c = EquipmentParameterNumber(hass, manager, system, equipment, parameter)
+    c.hass = hass
+    assert c.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT
+    assert c.unit_of_measurement == UnitOfTemperature.CELSIUS
+
+    hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+    assert c.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT
+    assert c.unit_of_measurement == UnitOfTemperature.FAHRENHEIT
 
 @pytest.mark.asyncio
 async def test_equipment_parameter_number_max_value(hass, manager: Manager):
@@ -63,6 +81,8 @@ async def test_equipment_parameter_number_max_value(hass, manager: Manager):
     equipment = system.equipment[0]
     parameter = equipment.parameters[72]
     c = EquipmentParameterNumber(hass, manager, system, equipment, parameter)
+    c.hass = hass
+    hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
     assert c.max_value == float(parameter.range_max)
 
 
@@ -72,6 +92,9 @@ async def test_equipment_parameter_number_min_value(hass, manager: Manager):
     equipment = system.equipment[0]
     parameter = equipment.parameters[72]
     c = EquipmentParameterNumber(hass, manager, system, equipment, parameter)
+    c.hass = hass
+    hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+
     assert c.min_value == float(parameter.range_min)
 
 
@@ -90,7 +113,17 @@ async def test_equipment_parameter_number_value(hass, manager: Manager):
     equipment = system.equipment[0]
     parameter = equipment.parameters[72]
     c = EquipmentParameterNumber(hass, manager, system, equipment, parameter)
-    assert c.value == parameter.value
+    c.hass = hass
+    hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+    assert c.value == float(parameter.value)
+
+    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+    assert c.value == float(parameter.value)
+
+    parameter = equipment.parameters[202]
+    c = EquipmentParameterNumber(hass, manager, system, equipment, parameter)
+    c.hass = hass
+    assert c.value == 21.1
 
 
 @pytest.mark.asyncio

--- a/tests/test_number_equipment_parameter_number.py
+++ b/tests/test_number_equipment_parameter_number.py
@@ -56,6 +56,8 @@ async def test_equipment_parameter_number_unit_of_measure(hass, manager: Manager
     c = EquipmentParameterNumber(hass, manager, system, equipment, parameter)
     c.hass = hass
 
+    # Parameters 72 is not an absolute temperature, so there should be no
+    # unit conversion
     hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
     assert c.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT
     assert c.unit_of_measurement == UnitOfTemperature.FAHRENHEIT
@@ -64,6 +66,8 @@ async def test_equipment_parameter_number_unit_of_measure(hass, manager: Manager
     assert c.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT
     assert c.unit_of_measurement == UnitOfTemperature.FAHRENHEIT
 
+    # Parameters 292 is an absolute temperature, so there should be
+    # unit conversion
     hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
     parameter = equipment.parameters[202]
     c = EquipmentParameterNumber(hass, manager, system, equipment, parameter)
@@ -114,12 +118,15 @@ async def test_equipment_parameter_number_value(hass, manager: Manager):
     parameter = equipment.parameters[72]
     c = EquipmentParameterNumber(hass, manager, system, equipment, parameter)
     c.hass = hass
+
+    # Parameters 72 is not an absolute temperature, so there should be no
+    # unit conversion
     hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
     assert c.value == float(parameter.value)
-
     hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
     assert c.value == float(parameter.value)
 
+    # Parameters 202 is an absolute temperature, so there should be conversion
     parameter = equipment.parameters[202]
     c = EquipmentParameterNumber(hass, manager, system, equipment, parameter)
     c.hass = hass

--- a/tests/test_number_equipment_parameter_number.py
+++ b/tests/test_number_equipment_parameter_number.py
@@ -8,8 +8,10 @@
 from unittest.mock import patch
 import pytest
 
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import UnitOfTemperature, UnitOfVolumeFlowRate
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.components.number import NumberDeviceClass
+
 
 from lennoxs30api.s30api_async import lennox_system
 
@@ -49,7 +51,7 @@ async def test_equipment_parameter_number_name(hass, manager: Manager):
 
 
 @pytest.mark.asyncio
-async def test_equipment_parameter_number_unit_of_measure(hass, manager: Manager):
+async def test_equipment_parameter_number_uom_device_class(hass, manager: Manager):
     system: lennox_system = manager.api.system_list[0]
     equipment = system.equipment[0]
     parameter = equipment.parameters[72]
@@ -61,6 +63,7 @@ async def test_equipment_parameter_number_unit_of_measure(hass, manager: Manager
     hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
     assert c.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT
     assert c.unit_of_measurement == UnitOfTemperature.FAHRENHEIT
+    assert c.device_class is None
 
     hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
     assert c.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT
@@ -74,10 +77,20 @@ async def test_equipment_parameter_number_unit_of_measure(hass, manager: Manager
     c.hass = hass
     assert c.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT
     assert c.unit_of_measurement == UnitOfTemperature.CELSIUS
+    assert c.device_class == NumberDeviceClass.TEMPERATURE
 
     hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
     assert c.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT
     assert c.unit_of_measurement == UnitOfTemperature.FAHRENHEIT
+
+    equipment = system.equipment[2]
+    parameter = equipment.parameters[19]
+    c = EquipmentParameterNumber(hass, manager, system, equipment, parameter)
+    c.hass = hass
+    assert c.native_unit_of_measurement == UnitOfVolumeFlowRate.CUBIC_FEET_PER_MINUTE
+    assert c.unit_of_measurement == UnitOfVolumeFlowRate.CUBIC_FEET_PER_MINUTE
+    assert c.device_class is None
+
 
 @pytest.mark.asyncio
 async def test_equipment_parameter_number_max_value(hass, manager: Manager):


### PR DESCRIPTION
Lennox provides equipment parameters only in F.  Equipment parameters numbers were not setting the device_class to temperature; preventing HA from automatically converting them to the users preferred unit system.

This fix:
- adds the appropriate device class for parameters that are absolute temperatures

