### PR TITLE
Correct return type of climate entity feature

### DIFF
--- a/custom_components/lennoxs30/climate.py
+++ b/custom_components/lennoxs30/climate.py
@@ -195,10 +195,10 @@ class S30Climate(S30BaseEntityMixin, ClimateEntity):
         return True
 
     @property
-    def supported_features(self):
+    def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
         if self.is_zone_disabled:
-            return 0
+            return ClimateEntityFeature(0)
 
         mask = SUPPORT_FLAGS
 

--- a/custom_components/lennoxs30/climate.py
+++ b/custom_components/lennoxs30/climate.py
@@ -197,23 +197,22 @@ class S30Climate(S30BaseEntityMixin, ClimateEntity):
     @property
     def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
-        if self.is_zone_disabled:
-            return ClimateEntityFeature(0)
+        mask: ClimateEntityFeature = ClimateEntityFeature(0)
+        if not self.is_zone_disabled:
+            mask = SUPPORT_FLAGS
 
-        mask = SUPPORT_FLAGS
+            # Target temperature.
+            # If its a cooling or heating only system, then there is only one setpoint
+            if self.is_single_setpoint_active():
+                mask |= ClimateEntityFeature.TARGET_TEMPERATURE
+            else:
+                mask |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
 
-        # Target temperature.
-        # If its a cooling or heating only system, then there is only one setpoint
-        if self.is_single_setpoint_active():
-            mask |= ClimateEntityFeature.TARGET_TEMPERATURE
-        else:
-            mask |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-
-        if (self._zone.humidificationOption or self._zone.dehumidificationOption) and (
-            self._zone.humidityMode == LENNOX_HUMIDITY_MODE_DEHUMIDIFY
-            or self._zone.humidityMode == LENNOX_HUMIDITY_MODE_HUMIDIFY
-        ):
-            mask |= ClimateEntityFeature.TARGET_HUMIDITY
+            if (self._zone.humidificationOption or self._zone.dehumidificationOption) and (
+                self._zone.humidityMode == LENNOX_HUMIDITY_MODE_DEHUMIDIFY
+                or self._zone.humidityMode == LENNOX_HUMIDITY_MODE_HUMIDIFY
+            ):
+                mask |= ClimateEntityFeature.TARGET_HUMIDITY
 
         _LOGGER.debug("climate:supported_features name [%s] support_flags [%d]", self._myname, SUPPORT_FLAGS)
         return mask

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -752,7 +752,7 @@ async def test_climate_supported_features(hass, manager_mz: Manager):
     assert feat != 0
     system.zoningMode = LENNOX_ZONING_MODE_CENTRAL
     feat = c1.supported_features
-    assert feat == 0
+    assert feat == ClimateEntityFeature(0)
     feat = c.supported_features
     assert feat != 0
 


### PR DESCRIPTION
Climate supported features is returning an integer zero when the zone is disabled; it should be returning a ClimateEntityFeature type instead.

```
Error adding entity None for domain climate with platform lennoxs30
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 825, in _async_add_entity
capabilities=entity.capability_attributes,
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/src/homeassistant/homeassistant/components/climate/init.py", line 386, in capability_attributes
if ClimateEntityFeature.TARGET_HUMIDITY in supported_features:
```

