### PR TITLE
Return zone hvac mode hvac action when in single zone mode

### DIFF
--- a/custom_components/lennoxs30/climate.py
+++ b/custom_components/lennoxs30/climate.py
@@ -367,8 +367,6 @@ class S30Climate(S30BaseEntityMixin, ClimateEntity):
     @property
     def hvac_mode(self):
         """Return the current hvac operation mode."""
-        if self.is_zone_disabled:
-            return None
         r = self._zone.getSystemMode()
         if r == LENNOX_HVAC_HEAT_COOL:
             r = HVACMode.HEAT_COOL
@@ -481,8 +479,6 @@ class S30Climate(S30BaseEntityMixin, ClimateEntity):
     @property
     def hvac_action(self):
         """Return the current hvac state/action."""
-        if self.is_zone_disabled:
-            return None
         to = self._zone.tempOperation
         ho = self._zone.humOperation
         if to != LENNOX_TEMP_OPERATION_OFF:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1000,7 +1000,7 @@ async def test_climate_hvac_mode(hass, manager_mz: Manager):
 
     system.zoningMode = LENNOX_ZONING_MODE_CENTRAL
     assert c.hvac_mode == HVACMode.HEAT
-    assert c1.hvac_mode is None
+    assert c1.hvac_mode == HVACMode.COOL
 
 
 @pytest.mark.asyncio
@@ -1137,7 +1137,8 @@ async def test_climate_hvac_action(hass, manager_mz: Manager):
     assert c.hvac_action == "unexpected_humdity_operation"
 
     system.zoningMode = LENNOX_ZONING_MODE_CENTRAL
-    assert c.hvac_action is None
+    zone.tempOperation = LENNOX_TEMP_OPERATION_COOLING
+    assert c.hvac_action == HVACAction.COOLING
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The integration would return None for hvac_action and hvac_mode when the zone was disable due to away mode or the user turning off central mode. Now, we will return the zones hvac_action and hvac_mode; which lennox keeps synchronized with the master zone. This prevent "Unknowns" from appearing in the lovelace thermostat card.