### PR TITLE
Filter bad hvac actions

### DIFF
--- a/custom_components/lennoxs30/climate.py
+++ b/custom_components/lennoxs30/climate.py
@@ -479,6 +479,8 @@ class S30Climate(S30BaseEntityMixin, ClimateEntity):
         """Return the current hvac state/action."""
         to = self._zone.tempOperation
         ho = self._zone.humOperation
+        if to not in HVACAction:
+            return HVACAction.IDLE
         if to != LENNOX_TEMP_OPERATION_OFF:
             return to
         if ho != LENNOX_TEMP_OPERATION_OFF:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1104,7 +1104,8 @@ async def test_climate_hvac_action(hass, manager_mz: Manager):
     manager = manager_mz
     system: lennox_system = manager.api.system_list[0]
     manager.is_metric = False
-    zone: lennox_zone = system.zone_list[1]
+    zone: lennox_zone = system.zone_list[0]
+
     c = S30Climate(hass, manager, system, zone)
 
     zone.systemMode = LENNOX_HVAC_OFF
@@ -1140,6 +1141,11 @@ async def test_climate_hvac_action(hass, manager_mz: Manager):
     zone.tempOperation = LENNOX_TEMP_OPERATION_COOLING
     assert c.hvac_action == HVACAction.COOLING
 
+    zone.systemMode = LENNOX_HVAC_COOL
+    zone.tempOperation = LENNOX_HUMID_OPERATION_WAITING
+    zone.humOperation = LENNOX_HUMID_OPERATION_OFF
+    assert c.hvac_action == HVACAction.IDLE
+    assert c.extra_state_attributes["tempOperation"] == LENNOX_HUMID_OPERATION_WAITING
 
 @pytest.mark.asyncio
 async def test_climate_preset_modes(hass, manager_mz: Manager):


### PR DESCRIPTION
If an invalid hvac_action is encountered Idle will be returned.

The lennox state will be in the attributes under tempOperation