### PR TITLE
Use the size of the active list

### DIFF
--- a/custom_components/lennoxs30/sensor.py
+++ b/custom_components/lennoxs30/sensor.py
@@ -741,7 +741,6 @@ class S30ActiveAlertsList(S30BaseEntityMixin, SensorEntity):
             [
                 "active_alerts",
                 "alerts_num_cleared",
-                "alerts_num_active",
                 "alerts_last_cleared_id",
                 "alerts_num_in_active_array",
             ],
@@ -777,6 +776,8 @@ class S30ActiveAlertsList(S30BaseEntityMixin, SensorEntity):
 
     @property
     def native_value(self):
+        if not self._system.active_alerts:
+            return 0
         return len(self._system.active_alerts)
 
     @property

--- a/custom_components/lennoxs30/sensor.py
+++ b/custom_components/lennoxs30/sensor.py
@@ -777,9 +777,7 @@ class S30ActiveAlertsList(S30BaseEntityMixin, SensorEntity):
 
     @property
     def native_value(self):
-        if (val := self._system.alerts_num_active) is None:
-            return 0
-        return val
+        return len(self._system.active_alerts)
 
     @property
     def state_class(self):

--- a/tests/test_sensor_active_alerts_list.py
+++ b/tests/test_sensor_active_alerts_list.py
@@ -53,7 +53,9 @@ async def test_active_alerts_sensor(hass, manager: Manager):
     assert attrs["alerts_last_cleared_id"] == 45
     assert attrs["alerts_num_in_active_array"] == 2
 
-    system.alerts_num_active = None
+    system.active_alerts = []
+    assert sensor.state == 0
+    system.active_alerts = None
     assert sensor.state == 0
 
     system.alerts_num_cleared = None
@@ -80,8 +82,8 @@ async def test_active_alerts_subscription(hass, manager: Manager):
 
     with patch.object(sensor, "schedule_update_ha_state") as update_callback:
         manager.is_metric = False
-        update = {"alerts_num_active": 4}
-        system.attr_updater(update, "alerts_num_active")
+        update = {"active_alerts": ["a","b","c","d"]}
+        system.attr_updater(update, "active_alerts")
         system.executeOnUpdateCallbacks()
         assert update_callback.call_count == 1
         assert sensor.state == 4


### PR DESCRIPTION
The sensor was using attribute "alert_num_in_active"; however, the integration is filtering alerts that are in the active list that are no longer active. Lennox for some reasons keeps recently cleared alerts in the list. The sensor will now use the length of the list keeping these values consistent.