### PR TITLE
fix: return DEFAULT_MIN_TEMP/DEFAULT_MAX_TEMP instead of None when system is off

### DIFF
--- a/custom_components/lennoxs30/climate.py
+++ b/custom_components/lennoxs30/climate.py
@@ -11,12 +11,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.components.climate import (
-    DEFAULT_MAX_TEMP,
-    DEFAULT_MIN_TEMP,
-    ClimateEntity,
-    ClimateEntityFeature,
-)
+from homeassistant.components.climate import ClimateEntity, ClimateEntityFeature
 from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
     ATTR_TARGET_TEMP_HIGH,
@@ -233,7 +228,13 @@ class S30Climate(S30BaseEntityMixin, ClimateEntity):
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         if self._zone.systemMode == LENNOX_HVAC_OFF or self._zone.systemMode is None or self.is_zone_disabled:
-            return DEFAULT_MIN_TEMP
+            if self._system.single_setpoint_mode:
+                if self._manager.is_metric is False:
+                    return self._zone.minCsp
+                return self._zone.minCspC
+            if self._manager.is_metric is False:
+                return self._zone.minHsp
+            return self._zone.minHspC
         if self._zone.systemMode == LENNOX_HVAC_COOL:
             if self._manager.is_metric is False:
                 return self._zone.minCsp
@@ -260,7 +261,13 @@ class S30Climate(S30BaseEntityMixin, ClimateEntity):
     def max_temp(self) -> float:
         """Return the maximum temperature."""
         if self._zone.systemMode == LENNOX_HVAC_OFF or self._zone.systemMode is None or self.is_zone_disabled:
-            return DEFAULT_MAX_TEMP
+            if self._system.single_setpoint_mode:
+                if self._manager.is_metric is False:
+                    return self._zone.maxHsp
+                return self._zone.maxHspC
+            if self._manager.is_metric is False:
+                return self._zone.maxCsp
+            return self._zone.maxCspC
         if self._zone.systemMode == LENNOX_HVAC_COOL:
             if self._manager.is_metric is False:
                 return self._zone.maxCsp

--- a/custom_components/lennoxs30/climate.py
+++ b/custom_components/lennoxs30/climate.py
@@ -11,7 +11,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.components.climate import ClimateEntity, ClimateEntityFeature
+from homeassistant.components.climate import (
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
+    ClimateEntity,
+    ClimateEntityFeature,
+)
 from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
     ATTR_TARGET_TEMP_HIGH,
@@ -225,10 +230,10 @@ class S30Climate(S30BaseEntityMixin, ClimateEntity):
         return UnitOfTemperature.CELSIUS
 
     @property
-    def min_temp(self) -> float | None:
+    def min_temp(self) -> float:
         """Return the minimum temperature."""
         if self._zone.systemMode == LENNOX_HVAC_OFF or self._zone.systemMode is None or self.is_zone_disabled:
-            return None
+            return DEFAULT_MIN_TEMP
         if self._zone.systemMode == LENNOX_HVAC_COOL:
             if self._manager.is_metric is False:
                 return self._zone.minCsp
@@ -252,10 +257,10 @@ class S30Climate(S30BaseEntityMixin, ClimateEntity):
         return super().min_temp
 
     @property
-    def max_temp(self) -> float | None:
+    def max_temp(self) -> float:
         """Return the maximum temperature."""
         if self._zone.systemMode == LENNOX_HVAC_OFF or self._zone.systemMode is None or self.is_zone_disabled:
-            return None
+            return DEFAULT_MAX_TEMP
         if self._zone.systemMode == LENNOX_HVAC_COOL:
             if self._manager.is_metric is False:
                 return self._zone.maxCsp

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -17,11 +17,7 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.const import UnitOfTemperature
-from homeassistant.components.climate import (
-    DEFAULT_MAX_TEMP,
-    DEFAULT_MIN_TEMP,
-    ClimateEntityFeature,
-)
+from homeassistant.components.climate import ClimateEntityFeature
 from homeassistant.helpers import issue_registry as ir
 
 from lennoxs30api.s30api_async import (
@@ -86,8 +82,8 @@ async def test_climate_min_max_c(hass, manager_mz: Manager):
     assert manager.is_metric is True
     assert c.temperature_unit == UnitOfTemperature.CELSIUS
     zone.systemMode = LENNOX_HVAC_OFF
-    assert c.min_temp == DEFAULT_MIN_TEMP
-    assert c.max_temp == DEFAULT_MAX_TEMP
+    assert c.min_temp == zone.minCspC
+    assert c.max_temp == zone.maxHspC
 
     zone.systemMode = LENNOX_HVAC_COOL
     assert c.min_temp == zone.minCspC
@@ -119,8 +115,8 @@ async def test_climate_min_max_c(hass, manager_mz: Manager):
     system.zoningMode = LENNOX_ZONING_MODE_CENTRAL
     assert c.min_temp == zone.minHspC
     assert c.max_temp == zone.maxCspC
-    assert c1.min_temp == DEFAULT_MIN_TEMP
-    assert c1.max_temp == DEFAULT_MAX_TEMP
+    assert c1.min_temp == zone1.minHspC
+    assert c1.max_temp == zone1.maxCspC
 
 
 @pytest.mark.asyncio
@@ -137,8 +133,8 @@ async def test_climate_min_max_f(hass, manager_mz: Manager, caplog):
     assert manager.is_metric is False
     assert c.temperature_unit == UnitOfTemperature.FAHRENHEIT
     zone.systemMode = LENNOX_HVAC_OFF
-    assert c.min_temp == DEFAULT_MIN_TEMP
-    assert c.max_temp == DEFAULT_MAX_TEMP
+    assert c.min_temp == zone.minCsp
+    assert c.max_temp == zone.maxHsp
 
     zone.systemMode = LENNOX_HVAC_COOL
     assert c.min_temp == zone.minCsp
@@ -170,8 +166,8 @@ async def test_climate_min_max_f(hass, manager_mz: Manager, caplog):
     system.zoningMode = LENNOX_ZONING_MODE_CENTRAL
     assert c.min_temp == zone.minHsp
     assert c.max_temp == zone.maxCsp
-    assert c1.min_temp == DEFAULT_MIN_TEMP
-    assert c1.max_temp == DEFAULT_MAX_TEMP
+    assert c1.min_temp == zone1.minHsp
+    assert c1.max_temp == zone1.maxCsp
     system.zoningMode = LENNOX_ZONING_MODE_ZONED
 
     with caplog.at_level(logging.WARNING):

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -17,7 +17,11 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.const import UnitOfTemperature
-from homeassistant.components.climate import ClimateEntityFeature
+from homeassistant.components.climate import (
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
+    ClimateEntityFeature,
+)
 from homeassistant.helpers import issue_registry as ir
 
 from lennoxs30api.s30api_async import (
@@ -82,8 +86,8 @@ async def test_climate_min_max_c(hass, manager_mz: Manager):
     assert manager.is_metric is True
     assert c.temperature_unit == UnitOfTemperature.CELSIUS
     zone.systemMode = LENNOX_HVAC_OFF
-    assert c.min_temp is None
-    assert c.max_temp is None
+    assert c.min_temp == DEFAULT_MIN_TEMP
+    assert c.max_temp == DEFAULT_MAX_TEMP
 
     zone.systemMode = LENNOX_HVAC_COOL
     assert c.min_temp == zone.minCspC
@@ -115,8 +119,8 @@ async def test_climate_min_max_c(hass, manager_mz: Manager):
     system.zoningMode = LENNOX_ZONING_MODE_CENTRAL
     assert c.min_temp == zone.minHspC
     assert c.max_temp == zone.maxCspC
-    assert c1.min_temp is None
-    assert c1.max_temp is None
+    assert c1.min_temp == DEFAULT_MIN_TEMP
+    assert c1.max_temp == DEFAULT_MAX_TEMP
 
 
 @pytest.mark.asyncio
@@ -133,8 +137,8 @@ async def test_climate_min_max_f(hass, manager_mz: Manager, caplog):
     assert manager.is_metric is False
     assert c.temperature_unit == UnitOfTemperature.FAHRENHEIT
     zone.systemMode = LENNOX_HVAC_OFF
-    assert c.min_temp is None
-    assert c.max_temp is None
+    assert c.min_temp == DEFAULT_MIN_TEMP
+    assert c.max_temp == DEFAULT_MAX_TEMP
 
     zone.systemMode = LENNOX_HVAC_COOL
     assert c.min_temp == zone.minCsp
@@ -166,8 +170,8 @@ async def test_climate_min_max_f(hass, manager_mz: Manager, caplog):
     system.zoningMode = LENNOX_ZONING_MODE_CENTRAL
     assert c.min_temp == zone.minHsp
     assert c.max_temp == zone.maxCsp
-    assert c1.min_temp is None
-    assert c1.max_temp is None
+    assert c1.min_temp == DEFAULT_MIN_TEMP
+    assert c1.max_temp == DEFAULT_MAX_TEMP
     system.zoningMode = LENNOX_ZONING_MODE_ZONED
 
     with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
## Summary

When `systemMode` is off, None, or the zone is disabled, `min_temp` and `max_temp` currently return `None`. This causes a `TypeError` crash in the HA `google_assistant` integration on every device sync, preventing the climate entity from appearing in Google Home.

## Root Cause

`TemperatureSettingTrait.sync_attributes()` in HA core calls `float()` on `ATTR_MIN_TEMP` and `ATTR_MAX_TEMP` without a None guard. The HA climate entity spec defines both properties as `float` with defaults (`DEFAULT_MIN_TEMP` = 7°C, `DEFAULT_MAX_TEMP` = 35°C) — returning `None` is out of spec.

Spec reference: https://developers.home-assistant.io/docs/core/entity/climate/

## Fix

Replace `return None` in `min_temp` and `max_temp` with `return DEFAULT_MIN_TEMP` and `return DEFAULT_MAX_TEMP` respectively. Update return type annotations from `float | None` to `float`.

## Related

Fixes home-assistant/core#173056