### PR TITLE
Add per-zone demand sensor

### DIFF
--- a/custom_components/lennoxs30/sensor.py
+++ b/custom_components/lennoxs30/sensor.py
@@ -125,6 +125,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     sensor_list.append(S30TempSensor(hass, manager, system, zone))
                     _LOGGER.debug("Create S30HumSensor sensor system [%s] zone [%s]", system.sysId, zone.id)
                     sensor_list.append(S30HumiditySensor(hass, manager, system, zone))
+                    # Zone CFM demand is only reported by variable-capacity systems; staged /
+                    # single-stage units leave zone.demand as None. Only create the sensor when
+                    # the device actually reports demand, to avoid a dead entity on non-variable
+                    # equipment. (A stricter alternative, pending testing on non-variable gear, is
+                    # to gate on the equipment capacity-type parameter: "Variable Capacity" /
+                    # "Load Tracking Variable Capacity" vs "Staged".)
+                    if zone.demand is not None:
+                        _LOGGER.debug("Create S30ZoneDemandSensor sensor system [%s] zone [%s]", system.sysId, zone.id)
+                        sensor_list.append(S30ZoneDemandSensor(hass, manager, system, zone))
 
         if manager.create_alert_sensors:
             sensor_list.append(S30AlertSensor(hass, manager, system))
@@ -561,6 +570,66 @@ class S30HumiditySensor(S30BaseEntityMixin, SensorEntity):
     @property
     def device_class(self):
         return SensorDeviceClass.HUMIDITY
+
+    @property
+    def state_class(self):
+        return SensorStateClass.MEASUREMENT
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return {
+            "identifiers": {(DOMAIN, self._zone.unique_id)},
+        }
+
+
+class S30ZoneDemandSensor(S30BaseEntityMixin, SensorEntity):
+    """Class for Lennox S30 zone demand - the CFM demand from the zone as a percentage."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        manager: Manager,
+        system: lennox_system,
+        zone: lennox_zone,
+    ):
+        super().__init__(manager, system)
+        self._hass = hass
+        self._zone = zone
+        self._myname = self._zone.system.name + "_" + self._zone.name + "_demand"
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        _LOGGER.debug("async_added_to_hass S30ZoneDemandSensor myname [%s]", self._myname)
+        self._zone.registerOnUpdateCallback(self.update_callback, ["demand"])
+        await super().async_added_to_hass()
+
+    def update_callback(self):
+        """Callback to execute on data change"""
+        _LOGGER.debug("update_callback S30ZoneDemandSensor myname [%s]", self._myname)
+        self.schedule_update_ha_state()
+
+    @property
+    def unique_id(self) -> str:
+        # HA fails with dashes in IDs
+        return (self._zone.system.unique_id + "_" + str(self._zone.id)).replace("-", "") + "_D"
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        return {}
+
+    @property
+    def name(self):
+        return self._myname
+
+    @property
+    def native_value(self):
+        return self._zone.demand
+
+    @property
+    def native_unit_of_measurement(self):
+        return PERCENTAGE
 
     @property
     def state_class(self):

--- a/tests/test_sensor_demand.py
+++ b/tests/test_sensor_demand.py
@@ -1,0 +1,64 @@
+# pylint: disable=too-many-lines
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=invalid-name
+# pylint: disable=protected-access
+# pylint: disable=line-too-long
+
+from unittest.mock import patch
+
+import pytest
+from homeassistant.components.sensor import SensorStateClass
+from homeassistant.const import PERCENTAGE
+from lennoxs30api.s30api_async import (
+    lennox_system,
+    lennox_zone,
+)
+
+from custom_components.lennoxs30 import Manager
+from custom_components.lennoxs30.const import LENNOX_DOMAIN
+from custom_components.lennoxs30.sensor import S30ZoneDemandSensor
+from tests.conftest import conftest_base_entity_availability
+
+
+@pytest.mark.asyncio()
+async def test_demand_sensor(hass, manager: Manager):
+    system: lennox_system = manager.api.system_list[0]
+    zone: lennox_zone = system.getZone(0)
+    s = S30ZoneDemandSensor(hass, manager, system, zone)
+
+    assert s.unique_id == (system.unique_id + "_" + str(zone.id) + "_D").replace("-", "")
+    assert s.name == system.name + "_" + zone.name + "_demand"
+    assert s.available is True
+    assert s.should_poll is False
+    assert s.update() is True
+    assert len(s.extra_state_attributes) == 0
+
+    assert s.state == zone.demand
+    assert s.unit_of_measurement == PERCENTAGE
+
+    # Demand has no dedicated device class - it is a generic percentage measurement
+    assert s.device_class is None
+    assert s.state_class == SensorStateClass.MEASUREMENT
+
+    identifiers = s.device_info["identifiers"]
+    for x in identifiers:
+        assert x[0] == LENNOX_DOMAIN
+        assert x[1] == zone.unique_id
+
+
+@pytest.mark.asyncio()
+async def test_demand_sensor_subscription(hass, manager: Manager):
+    system: lennox_system = manager.api.system_list[0]
+    zone: lennox_zone = system.getZone(0)
+    s = S30ZoneDemandSensor(hass, manager, system, zone)
+    await s.async_added_to_hass()
+
+    with patch.object(s, "schedule_update_ha_state") as update_callback:
+        update_set = {"demand": (zone.demand or 0) + 10}
+        zone.attr_updater(update_set, "demand")
+        zone.executeOnUpdateCallbacks()
+        assert update_callback.call_count == 1
+        assert s.state == zone.demand
+
+    conftest_base_entity_availability(manager, system, s)

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -23,6 +23,7 @@ from custom_components.lennoxs30.sensor import (
     S30InverterPowerSensor,
     S30OutdoorTempSensor,
     S30TempSensor,
+    S30ZoneDemandSensor,
     async_setup_entry,
 )
 from custom_components.lennoxs30.sensor_ble import S40BleSensor
@@ -166,10 +167,11 @@ async def test_async_setup_entry(hass, manager: Manager, caplog):
         await async_setup_entry(hass, entry, async_add_entities)
         assert async_add_entities.called == 1
         sensor_list = async_add_entities.call_args[0][0]
-        assert len(sensor_list) == 2 * system.numberOfZones
+        assert len(sensor_list) == 3 * system.numberOfZones
         for i in range(system.numberOfZones):
-            assert isinstance(sensor_list[i * 2], S30TempSensor)
-            assert isinstance(sensor_list[(i * 2) + 1], S30HumiditySensor)
+            assert isinstance(sensor_list[i * 3], S30TempSensor)
+            assert isinstance(sensor_list[(i * 3) + 1], S30HumiditySensor)
+            assert isinstance(sensor_list[(i * 3) + 2], S30ZoneDemandSensor)
         assert len(caplog.records) == 0
 
     # Diagnostic Sensors
@@ -338,3 +340,38 @@ async def test_async_setup_entry(hass, manager: Manager, caplog):
 
     sensor: WTEnvSensor = sensor_list[9]
     assert sensor.native_unit_of_measurement == UnitOfTemperature.FAHRENHEIT
+
+
+@pytest.mark.asyncio()
+async def test_zone_demand_sensor_skipped_when_no_demand(hass, manager: Manager):
+    """A demand sensor must NOT be created for zones that do not report CFM demand.
+
+    Staged / single-stage / non-variable-capacity units leave zone.demand == None,
+    so only temperature and humidity sensors should be created for those zones.
+    """
+    system: lennox_system = manager.api.system_list[0]
+    entry = manager.config_entry
+    hass.data["lennoxs30"] = {}
+    hass.data["lennoxs30"][entry.unique_id] = {MANAGER: manager}
+
+    system.outdoorTemperatureStatus = LENNOX_STATUS_NOT_EXIST
+    manager.create_inverter_power = False
+    manager.create_sensors = True
+    manager.create_diagnostic_sensors = False
+    manager.create_alert_sensors = False
+    manager.api.isLANConnection = False
+
+    # Simulate non-variable equipment: no zone reports a CFM demand
+    for zone in system.zone_list:
+        zone.demand = None
+
+    async_add_entities = Mock()
+    await async_setup_entry(hass, entry, async_add_entities)
+    sensor_list = async_add_entities.call_args[0][0]
+
+    assert not any(isinstance(s, S30ZoneDemandSensor) for s in sensor_list)
+    # Temp + humidity are still created for each active zone (2 per zone, no demand sensor)
+    assert len(sensor_list) == 2 * system.numberOfZones
+    for i in range(system.numberOfZones):
+        assert isinstance(sensor_list[i * 2], S30TempSensor)
+        assert isinstance(sensor_list[(i * 2) + 1], S30HumiditySensor)


### PR DESCRIPTION
## Summary
Adds an `S30ZoneDemandSensor` that exposes each active zone's CFM demand as a
percentage. It is registered per active zone alongside the existing temperature
and humidity sensors, reads `zone.demand`, and refreshes on the `demand`
attribute-update callback.

Zone CFM demand is only reported by variable-capacity systems; staged /
single-stage units leave `zone.demand` as `None`. The sensor is therefore created
only when the device actually reports demand (gated on `zone.demand is not None`,
mirroring `is_zone_active()`'s temperature-based gating), so non-variable
equipment does not get a dead entity.

- Unit: `%` (PERCENTAGE)
- State class: `measurement`
- Device class: none (generic percentage)
- unique_id: `<zone.system.unique_id>_<zone.id>_D` (dashes stripped, HA-safe)
- Tied to the existing per-zone device via `device_info` identifiers.

## Testing
- New `tests/test_sensor_demand.py` (value/availability/attrs + update-callback subscription).
- `tests/test_sensor_setup.py`: three sensors per zone when demand is reported, plus a
  negative test that no demand sensor is created when `zone.demand is None`.
- Full suite: 288 passed, 4 skipped (py3.14, pytest-homeassistant-custom-component 0.13.338).

## Notes
- Requires `lennoxs30api>=0.2.23` (already pinned in manifest), which provides `lennox_zone.demand`.
- Creation is decided at setup time; a zone that only starts reporting demand later
  picks up the sensor on the next integration reload (same as other data-gated entities).
