### PR TITLE
Protect against crash on empty zone name

### DIFF
--- a/custom_components/lennoxs30/__init__.py
+++ b/custom_components/lennoxs30/__init__.py
@@ -74,6 +74,7 @@ from .device import (
     S30ZoneThermostat,
     S40BleDevice,
 )
+from .helpers import helper_create_zone_entity_name
 from .util import dict_redact_fields
 
 DOMAIN = LENNOX_DOMAIN
@@ -690,6 +691,15 @@ class Manager:
 
             for zone in system.zone_list:
                 if zone.is_zone_active():
+                    if zone.name is None or str(zone.name).strip() == "":
+                        fallback_name = helper_create_zone_entity_name(system, zone)
+                        _LOGGER.warning(
+                            "create_devices active zone missing name host [%s] sysId [%s] zone_id [%s] using fallback [%s]; this usually indicates incomplete zone config message delivery",
+                            self._ip_address,
+                            system.sysId,
+                            zone.id,
+                            fallback_name,
+                        )
                     z: S30ZoneThermostat = S30ZoneThermostat(self._hass, self.config_entry, system, zone, s30)
                     z.register_device()
 

--- a/custom_components/lennoxs30/device.py
+++ b/custom_components/lennoxs30/device.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from lennoxs30api.s30api_async import LennoxBle, lennox_equipment, lennox_system, lennox_zone
 
 from .const import LENNOX_DOMAIN, LENNOX_MFG
+from .helpers import helper_create_zone_entity_name
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class Device:
@@ -287,12 +292,20 @@ class S30ZoneThermostat(Device):
     def register_device(self) -> None:
         """Register the device with HASS."""
         device_registry = dr.async_get(self._hass)
+        name = helper_create_zone_entity_name(self._system, self._zone)
+        if self._zone.name is None or str(self._zone.name).strip() == "":
+            _LOGGER.warning(
+                "register_device using fallback zone name for sysId [%s] zone_id [%s] generated_name [%s]",
+                self._system.sysId,
+                self._zone.id,
+                name,
+            )
 
         device_registry.async_get_or_create(
             config_entry_id=self._config_entry.entry_id,
             identifiers={(LENNOX_DOMAIN, self.unique_name)},
             manufacturer=LENNOX_MFG,
-            name=self._system.name + "_" + self._zone.name,
+            name=name,
             model="thermostat",
             via_device=(LENNOX_DOMAIN, self._s30_controller_device.unique_name),
         )

--- a/custom_components/lennoxs30/device.py
+++ b/custom_components/lennoxs30/device.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -11,8 +9,6 @@ from lennoxs30api.s30api_async import LennoxBle, lennox_equipment, lennox_system
 
 from .const import LENNOX_DOMAIN, LENNOX_MFG
 from .helpers import helper_create_zone_entity_name
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class Device:
@@ -293,13 +289,6 @@ class S30ZoneThermostat(Device):
         """Register the device with HASS."""
         device_registry = dr.async_get(self._hass)
         name = helper_create_zone_entity_name(self._system, self._zone)
-        if self._zone.name is None or str(self._zone.name).strip() == "":
-            _LOGGER.warning(
-                "register_device using fallback zone name for sysId [%s] zone_id [%s] generated_name [%s]",
-                self._system.sysId,
-                self._zone.id,
-                name,
-            )
 
         device_registry.async_get_or_create(
             config_entry_id=self._config_entry.entry_id,

--- a/custom_components/lennoxs30/helpers.py
+++ b/custom_components/lennoxs30/helpers.py
@@ -10,7 +10,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import (
     PERCENTAGE,
@@ -21,10 +21,13 @@ from homeassistant.const import (
     UnitOfTime,
     UnitOfVolumeFlowRate,
 )
-from lennoxs30api import lennox_system
+from lennoxs30api import lennox_system, lennox_zone
 from lennoxs30api.lennox_equipment import lennox_equipment, lennox_equipment_parameter
 
-from . import DOMAIN, Manager
+from .const import LENNOX_DOMAIN
+
+if TYPE_CHECKING:
+    from . import Manager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,14 +57,14 @@ def lennox_uom_to_ha_uom(unit: str) -> str:
     return unit
 
 
-def helper_get_equipment_device_info(manager: Manager, system: lennox_system, equipment_id: int) -> dict:
+def helper_get_equipment_device_info(manager: "Manager", system: lennox_system, equipment_id: int) -> dict:
     """Construct the HASS device info for an entity."""
     equip_device_map = manager.system_equip_device_map.get(system.sysId)
     if equip_device_map is not None:
         device = equip_device_map.get(equipment_id)
         if device is not None:
             return {
-                "identifiers": {(DOMAIN, device.unique_name)},
+                "identifiers": {(LENNOX_DOMAIN, device.unique_name)},
             }
         _LOGGER.warning(
             "helper_get_equipment_device_info Unable to find equipment_id [%s] in device map sysId [%s], please raise an issue",
@@ -75,7 +78,7 @@ def helper_get_equipment_device_info(manager: Manager, system: lennox_system, eq
             equipment_id,
         )
     return {
-        "identifiers": {(DOMAIN, system.unique_id)},
+        "identifiers": {(LENNOX_DOMAIN, system.unique_id)},
     }
 
 
@@ -106,6 +109,23 @@ def helper_create_system_unique_id(system: lennox_system, suffix: str) -> str:
     """Construct a unique name for a system entity."""
     result = system.unique_id + suffix
     return result.replace(" ", "_").replace("-", "").replace(".", "").replace("__", "_")
+
+
+def helper_create_zone_entity_name(system: lennox_system, zone: lennox_zone) -> str:
+    """Create a stable name for zone entities and zone devices."""
+    system_name: str = ""
+    if system.name is not None:
+        system_name = str(system.name).strip()
+    if system_name == "":
+        system_name = f"system_{system.sysId}"
+
+    zone_name: str = ""
+    if zone.name is not None:
+        zone_name = str(zone.name).strip()
+    if zone_name == "":
+        zone_name = f"Zone_{zone.id}"
+
+    return f"{system_name}_{zone_name}"
 
 
 def helper_get_parameter_extra_attributes(equipment: lennox_equipment, parameter: lennox_equipment_parameter) -> dict[str, Any]:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -6,6 +6,8 @@
 # pylint: disable=protected-access
 # pylint: disable=line-too-long
 
+import logging
+
 from unittest.mock import patch
 
 import pytest
@@ -465,6 +467,30 @@ async def test_create_device_no_equipment(hass, manager_system_04_furn_ac_zoning
             break
         assert elem[0] == DOMAIN
         assert elem[1] == manager.api.system_list[0].unique_id + "_iu"
+
+
+@pytest.mark.asyncio()
+async def test_create_devices_zone_name_missing(hass, manager: Manager, caplog):
+    """Create devices should continue with a fallback zone name when zone.name is missing."""
+    device_registry = dr.async_get(hass)
+    system = manager.api.system_list[0]
+    zone: lennox_zone = system.zone_list[0]
+    zone.name = None
+
+    with patch.object(device_registry, "async_get_or_create") as mock_create_device:
+        with caplog.at_level(logging.WARNING):
+            caplog.clear()
+            await manager.create_devices()
+
+    zone_call = None
+    for call in mock_create_device.mock_calls:
+        if call.kwargs.get("model") == "thermostat":
+            zone_call = call
+            break
+
+    assert zone_call is not None
+    assert zone_call.kwargs["name"] == f"{system.name}_Zone_{zone.id}"
+    assert "create_devices active zone missing name" in caplog.text
 
 
 @pytest.mark.asyncio()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -113,6 +113,7 @@ async def test_helpers_create_zone_entity_name(manager: Manager):
     """Test the helper to create zone names with and without fallbacks."""
     system = manager.api.system_list[0]
     zone = system.zone_list[0]
+    original_system_name = system.name
 
     zone.name = "Main Floor"
     assert helper_create_zone_entity_name(system, zone) == f"{system.name}_Main Floor"
@@ -122,3 +123,12 @@ async def test_helpers_create_zone_entity_name(manager: Manager):
 
     zone.name = "   "
     assert helper_create_zone_entity_name(system, zone) == f"{system.name}_Zone_{zone.id}"
+
+    zone.name = "Main Floor"
+    system.name = None
+    assert helper_create_zone_entity_name(system, zone) == f"system_{system.sysId}_Main Floor"
+
+    system.name = "   "
+    assert helper_create_zone_entity_name(system, zone) == f"system_{system.sysId}_Main Floor"
+
+    system.name = original_system_name

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,6 +18,7 @@ from custom_components.lennoxs30 import Manager
 from custom_components.lennoxs30.const import LENNOX_DOMAIN
 from custom_components.lennoxs30.helpers import (
     helper_create_equipment_entity_name,
+    helper_create_zone_entity_name,
     helper_get_equipment_device_info,
     lennox_uom_to_ha_uom,
 )
@@ -105,3 +106,19 @@ async def test_helpers_create_equipment_entity_name(manager: Manager):
     assert helper_create_equipment_entity_name(system, equipment, "test..") == f"{system.name}_iu_test".replace(" ", "_")
 
     assert helper_create_equipment_entity_name(system, equipment, "test - h") == f"{system.name}_iu_test_h".replace(" ", "_")
+
+
+@pytest.mark.asyncio()
+async def test_helpers_create_zone_entity_name(manager: Manager):
+    """Test the helper to create zone names with and without fallbacks."""
+    system = manager.api.system_list[0]
+    zone = system.zone_list[0]
+
+    zone.name = "Main Floor"
+    assert helper_create_zone_entity_name(system, zone) == f"{system.name}_Main Floor"
+
+    zone.name = None
+    assert helper_create_zone_entity_name(system, zone) == f"{system.name}_Zone_{zone.id}"
+
+    zone.name = "   "
+    assert helper_create_zone_entity_name(system, zone) == f"{system.name}_Zone_{zone.id}"


### PR DESCRIPTION
If lennox failrs to deliver the zone configuration, crashing may occur when accessing zone.name

Protect against this and add a log warning to indicate the issue was encountered