### PR TITLE
Fix deprecated concentration unit constants

### DIFF
--- a/custom_components/lennoxs30/ble_device_21p02.py
+++ b/custom_components/lennoxs30/ble_device_21p02.py
@@ -1,22 +1,12 @@
 """Lennox BLE Air Quality Sensor."""
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+from homeassistant.const import (
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfDensity,
+    UnitOfRatio,
+)
 from homeassistant.helpers.entity import EntityCategory
-
-try:
-    from homeassistant.const import UnitOfDensity, UnitOfRatio
-except ImportError:
-    from homeassistant.const import (
-        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-        CONCENTRATION_PARTS_PER_MILLION,
-    )
-
-    UNIT_MICROGRAMS_PER_CUBIC_METER = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-    UNIT_PARTS_PER_MILLION = CONCENTRATION_PARTS_PER_MILLION
-else:
-    UNIT_MICROGRAMS_PER_CUBIC_METER = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
-    UNIT_PARTS_PER_MILLION = UnitOfRatio.PARTS_PER_MILLION
 
 lennox_21p02_sensors = [
     {
@@ -48,7 +38,7 @@ lennox_21p02_sensors = [
         "name": "pm25",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.PM25,
-        "uom": UNIT_MICROGRAMS_PER_CUBIC_METER,
+        "uom": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
     },
     {
         "input_id": 4103,
@@ -56,7 +46,7 @@ lennox_21p02_sensors = [
         "name": "co2",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.CO2,
-        "uom": UNIT_PARTS_PER_MILLION,
+        "uom": UnitOfRatio.PARTS_PER_MILLION,
     },
     {
         "input_id": 4105,
@@ -64,7 +54,7 @@ lennox_21p02_sensors = [
         "name": "voc",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
-        "uom": UNIT_MICROGRAMS_PER_CUBIC_METER,
+        "uom": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         "precision": 2,
     },
 ]
@@ -94,7 +84,7 @@ lennox_iaq_sensors = [
         "name": "pm25 sta",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.PM25,
-        "uom": UNIT_MICROGRAMS_PER_CUBIC_METER,
+        "uom": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         "precision": 4,
     },
     {
@@ -103,7 +93,7 @@ lennox_iaq_sensors = [
         "name": "pm25 lta",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.PM25,
-        "uom": UNIT_MICROGRAMS_PER_CUBIC_METER,
+        "uom": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         "precision": 4,
     },
     {
@@ -116,7 +106,7 @@ lennox_iaq_sensors = [
         "name": "voc sta",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
-        "uom": UNIT_MICROGRAMS_PER_CUBIC_METER,
+        "uom": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         "precision": 2,
     },
     {
@@ -125,7 +115,7 @@ lennox_iaq_sensors = [
         "name": "voc lta",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
-        "uom": UNIT_MICROGRAMS_PER_CUBIC_METER,
+        "uom": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         "precision": 2,
     },
     {
@@ -138,7 +128,7 @@ lennox_iaq_sensors = [
         "name": "co2 lta",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.CO2,
-        "uom": UNIT_PARTS_PER_MILLION,
+        "uom": UnitOfRatio.PARTS_PER_MILLION,
         "precision": 1,
     },
     {
@@ -147,7 +137,7 @@ lennox_iaq_sensors = [
         "name": "co2 sta",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.CO2,
-        "uom": UNIT_PARTS_PER_MILLION,
+        "uom": UnitOfRatio.PARTS_PER_MILLION,
         "precision": 1,
     },
     {

--- a/custom_components/lennoxs30/ble_device_21p02.py
+++ b/custom_components/lennoxs30/ble_device_21p02.py
@@ -1,12 +1,22 @@
 """Lennox BLE Air Quality Sensor."""
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_MILLION,
-    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-)
+from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT
 from homeassistant.helpers.entity import EntityCategory
+
+try:
+    from homeassistant.const import UnitOfDensity, UnitOfRatio
+except ImportError:
+    from homeassistant.const import (
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        CONCENTRATION_PARTS_PER_MILLION,
+    )
+
+    UNIT_MICROGRAMS_PER_CUBIC_METER = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    UNIT_PARTS_PER_MILLION = CONCENTRATION_PARTS_PER_MILLION
+else:
+    UNIT_MICROGRAMS_PER_CUBIC_METER = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
+    UNIT_PARTS_PER_MILLION = UnitOfRatio.PARTS_PER_MILLION
 
 lennox_21p02_sensors = [
     {
@@ -38,7 +48,7 @@ lennox_21p02_sensors = [
         "name": "pm25",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.PM25,
-        "uom": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        "uom": UNIT_MICROGRAMS_PER_CUBIC_METER,
     },
     {
         "input_id": 4103,
@@ -46,7 +56,7 @@ lennox_21p02_sensors = [
         "name": "co2",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.CO2,
-        "uom": CONCENTRATION_PARTS_PER_MILLION,
+        "uom": UNIT_PARTS_PER_MILLION,
     },
     {
         "input_id": 4105,
@@ -54,7 +64,7 @@ lennox_21p02_sensors = [
         "name": "voc",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
-        "uom": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        "uom": UNIT_MICROGRAMS_PER_CUBIC_METER,
         "precision": 2,
     },
 ]
@@ -84,7 +94,7 @@ lennox_iaq_sensors = [
         "name": "pm25 sta",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.PM25,
-        "uom": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        "uom": UNIT_MICROGRAMS_PER_CUBIC_METER,
         "precision": 4,
     },
     {
@@ -93,7 +103,7 @@ lennox_iaq_sensors = [
         "name": "pm25 lta",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.PM25,
-        "uom": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        "uom": UNIT_MICROGRAMS_PER_CUBIC_METER,
         "precision": 4,
     },
     {
@@ -106,7 +116,7 @@ lennox_iaq_sensors = [
         "name": "voc sta",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
-        "uom": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        "uom": UNIT_MICROGRAMS_PER_CUBIC_METER,
         "precision": 2,
     },
     {
@@ -115,7 +125,7 @@ lennox_iaq_sensors = [
         "name": "voc lta",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
-        "uom": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        "uom": UNIT_MICROGRAMS_PER_CUBIC_METER,
         "precision": 2,
     },
     {
@@ -128,7 +138,7 @@ lennox_iaq_sensors = [
         "name": "co2 lta",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.CO2,
-        "uom": CONCENTRATION_PARTS_PER_MILLION,
+        "uom": UNIT_PARTS_PER_MILLION,
         "precision": 1,
     },
     {
@@ -137,7 +147,7 @@ lennox_iaq_sensors = [
         "name": "co2 sta",
         "state_class": SensorStateClass.MEASUREMENT,
         "device_class": SensorDeviceClass.CO2,
-        "uom": CONCENTRATION_PARTS_PER_MILLION,
+        "uom": UNIT_PARTS_PER_MILLION,
         "precision": 1,
     },
     {

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
     "name": "Lennox S30,E30,M30",
     "render_readme": true,
     "hide_default_branch": true,
-    "homeassistant": "2026.3.0"
+    "homeassistant": "2026.7.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest-homeassistant-custom-component==0.13.338
-syrupy==5.2.0
+pytest-homeassistant-custom-component==0.13.344
+syrupy==5.3.2
 setuptools
 lennoxs30api==0.2.23

--- a/tests/test_sensor_iaq.py
+++ b/tests/test_sensor_iaq.py
@@ -1,24 +1,18 @@
 """Test BLE Sensors"""
 
 # pylint: disable=line-too-long
-import importlib.util
 import logging
-from types import SimpleNamespace
 from unittest.mock import patch
 
-import homeassistant.const
 import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfDensity, UnitOfRatio
 from lennoxs30api.s30api_async import lennox_system
 
 from custom_components.lennoxs30 import Manager
-from custom_components.lennoxs30 import ble_device_21p02
 from custom_components.lennoxs30.const import LENNOX_DOMAIN
 from custom_components.lennoxs30.sensor import S40IAQSensor, lennox_21p02_sensors, lennox_iaq_sensors
 from tests.conftest import conftest_base_entity_availability
-
-UNIT_MICROGRAMS_PER_CUBIC_METER = "μg/m³"
-UNIT_PARTS_PER_MILLION = "ppm"
 
 
 @pytest.mark.asyncio()
@@ -41,7 +35,7 @@ async def test_iaq_sensor(hass, manager_system_04_furn_ac_zoning_ble: Manager, c
     assert sensor.extra_state_attributes is None
     assert sensor.native_value == round(system.iaq_pm25_lta, sensor_dict["precision"])
     assert sensor.entity_category is None
-    assert sensor.native_unit_of_measurement == UNIT_MICROGRAMS_PER_CUBIC_METER
+    assert sensor.native_unit_of_measurement == UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
 
     system.iaq_pm25_lta_valid = False
     assert sensor.available is False
@@ -70,43 +64,15 @@ async def test_iaq_sensor(hass, manager_system_04_furn_ac_zoning_ble: Manager, c
 def test_air_quality_sensor_units():
     """Test air quality sensor units on supported Home Assistant versions."""
     ble_sensors = {sensor["name"]: sensor for sensor in lennox_21p02_sensors}
-    assert ble_sensors["pm25"]["uom"] == UNIT_MICROGRAMS_PER_CUBIC_METER
-    assert ble_sensors["voc"]["uom"] == UNIT_MICROGRAMS_PER_CUBIC_METER
-    assert ble_sensors["co2"]["uom"] == UNIT_PARTS_PER_MILLION
+    assert ble_sensors["pm25"]["uom"] == UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
+    assert ble_sensors["voc"]["uom"] == UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
+    assert ble_sensors["co2"]["uom"] == UnitOfRatio.PARTS_PER_MILLION
 
     iaq_sensors = {sensor["name"]: sensor for sensor in lennox_iaq_sensors}
     for name in ("pm25 sta", "pm25 lta", "voc sta", "voc lta"):
-        assert iaq_sensors[name]["uom"] == UNIT_MICROGRAMS_PER_CUBIC_METER
+        assert iaq_sensors[name]["uom"] == UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
     for name in ("co2 sta", "co2 lta"):
-        assert iaq_sensors[name]["uom"] == UNIT_PARTS_PER_MILLION
-
-
-def test_air_quality_sensor_modern_units(monkeypatch):
-    """Test that newer Home Assistant unit enums are preferred when available."""
-    modern_density_unit = "modern-density-unit"
-    modern_ratio_unit = "modern-ratio-unit"
-    monkeypatch.setattr(
-        homeassistant.const,
-        "UnitOfDensity",
-        SimpleNamespace(MICROGRAMS_PER_CUBIC_METER=modern_density_unit),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        homeassistant.const,
-        "UnitOfRatio",
-        SimpleNamespace(PARTS_PER_MILLION=modern_ratio_unit),
-        raising=False,
-    )
-
-    spec = importlib.util.spec_from_file_location("lennoxs30_ble_device_modern_test", ble_device_21p02.__file__)
-    assert spec is not None
-    assert spec.loader is not None
-    modern_module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(modern_module)
-
-    ble_sensors = {sensor["name"]: sensor for sensor in modern_module.lennox_21p02_sensors}
-    assert ble_sensors["pm25"]["uom"] == modern_density_unit
-    assert ble_sensors["co2"]["uom"] == modern_ratio_unit
+        assert iaq_sensors[name]["uom"] == UnitOfRatio.PARTS_PER_MILLION
 
 
 @pytest.mark.asyncio()

--- a/tests/test_sensor_iaq.py
+++ b/tests/test_sensor_iaq.py
@@ -1,18 +1,24 @@
 """Test BLE Sensors"""
 
 # pylint: disable=line-too-long
+import importlib.util
 import logging
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import homeassistant.const
 import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 from lennoxs30api.s30api_async import lennox_system
 
 from custom_components.lennoxs30 import Manager
+from custom_components.lennoxs30 import ble_device_21p02
 from custom_components.lennoxs30.const import LENNOX_DOMAIN
-from custom_components.lennoxs30.sensor import S40IAQSensor, lennox_iaq_sensors
+from custom_components.lennoxs30.sensor import S40IAQSensor, lennox_21p02_sensors, lennox_iaq_sensors
 from tests.conftest import conftest_base_entity_availability
+
+UNIT_MICROGRAMS_PER_CUBIC_METER = "μg/m³"
+UNIT_PARTS_PER_MILLION = "ppm"
 
 
 @pytest.mark.asyncio()
@@ -35,7 +41,7 @@ async def test_iaq_sensor(hass, manager_system_04_furn_ac_zoning_ble: Manager, c
     assert sensor.extra_state_attributes is None
     assert sensor.native_value == round(system.iaq_pm25_lta, sensor_dict["precision"])
     assert sensor.entity_category is None
-    assert sensor.native_unit_of_measurement == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    assert sensor.native_unit_of_measurement == UNIT_MICROGRAMS_PER_CUBIC_METER
 
     system.iaq_pm25_lta_valid = False
     assert sensor.available is False
@@ -59,6 +65,48 @@ async def test_iaq_sensor(hass, manager_system_04_furn_ac_zoning_ble: Manager, c
     sensor_dict = lennox_iaq_sensors[0]
     sensor = S40IAQSensor(hass, manager, system, ble_device, sensor_dict)
     assert sensor.native_value == system.iaq_mitigation_action
+
+
+def test_air_quality_sensor_units():
+    """Test air quality sensor units on supported Home Assistant versions."""
+    ble_sensors = {sensor["name"]: sensor for sensor in lennox_21p02_sensors}
+    assert ble_sensors["pm25"]["uom"] == UNIT_MICROGRAMS_PER_CUBIC_METER
+    assert ble_sensors["voc"]["uom"] == UNIT_MICROGRAMS_PER_CUBIC_METER
+    assert ble_sensors["co2"]["uom"] == UNIT_PARTS_PER_MILLION
+
+    iaq_sensors = {sensor["name"]: sensor for sensor in lennox_iaq_sensors}
+    for name in ("pm25 sta", "pm25 lta", "voc sta", "voc lta"):
+        assert iaq_sensors[name]["uom"] == UNIT_MICROGRAMS_PER_CUBIC_METER
+    for name in ("co2 sta", "co2 lta"):
+        assert iaq_sensors[name]["uom"] == UNIT_PARTS_PER_MILLION
+
+
+def test_air_quality_sensor_modern_units(monkeypatch):
+    """Test that newer Home Assistant unit enums are preferred when available."""
+    modern_density_unit = "modern-density-unit"
+    modern_ratio_unit = "modern-ratio-unit"
+    monkeypatch.setattr(
+        homeassistant.const,
+        "UnitOfDensity",
+        SimpleNamespace(MICROGRAMS_PER_CUBIC_METER=modern_density_unit),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        homeassistant.const,
+        "UnitOfRatio",
+        SimpleNamespace(PARTS_PER_MILLION=modern_ratio_unit),
+        raising=False,
+    )
+
+    spec = importlib.util.spec_from_file_location("lennoxs30_ble_device_modern_test", ble_device_21p02.__file__)
+    assert spec is not None
+    assert spec.loader is not None
+    modern_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(modern_module)
+
+    ble_sensors = {sensor["name"]: sensor for sensor in modern_module.lennox_21p02_sensors}
+    assert ble_sensors["pm25"]["uom"] == modern_density_unit
+    assert ble_sensors["co2"]["uom"] == modern_ratio_unit
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## What

- Replace the deprecated concentration constants with `UnitOfDensity.MICROGRAMS_PER_CUBIC_METER` and `UnitOfRatio.PARTS_PER_MILLION`.
- Raise the HACS minimum Home Assistant version to 2026.7.0, where the replacement enums were introduced.
- Add coverage for every affected BLE/IAQ sensor unit.

## Why

Home Assistant 2026.8 warns that the legacy concentration constants will be removed in 2027.8.

I've already applied this patch to my own Home Assistant 2026.8.0 instance, where the integration is running normally and the deprecation warnings no longer appear. Since it resolved the issue locally, I thought it was worth contributing upstream.

Fixes #428.

## Impact

The sensor unit values remain unchanged (`μg/m³` and `ppm`). Current Home Assistant versions stop emitting the deprecation warnings. HACS now requires Home Assistant 2026.7.0 or newer.

## Root cause

The BLE air-quality sensor definitions imported deprecated aliases directly from `homeassistant.const`.

## Validation

- Focused sensor tests on Home Assistant 2026.7.0: 3 passed.
- Full suite: 288 passed, 4 skipped.
- All seven pre-commit hooks passed.
- Running locally on Home Assistant 2026.8.0 with the expected units and no deprecated-constant warnings.
