### PR TITLE
Cloud connections zone name not initialized

### DIFF
--- a/custom_components/lennoxs30/__init__.py
+++ b/custom_components/lennoxs30/__init__.py
@@ -780,13 +780,17 @@ class Manager:
                 if lsystem.config_complete() is False:
                     continue
                 numZones = len(lsystem.zone_list)
+                numActiveZones = sum(1 for z in lsystem.zone_list if z.is_zone_active())
+                numZoneNames = sum(1 for z in lsystem.zone_list if z.is_zone_active() and z.name is not None and str(z.name).strip() != "")
                 _LOGGER.debug(
-                    "configuration_initialization host [%s] wait for zones system [%s] numZone [%d]",
+                    "configuration_initialization host [%s] wait for zones system [%s] numZone [%d] activeZones [%d] namedZones [%d]",
                     self._ip_address,
                     lsystem.sysId,
                     numZones,
+                    numActiveZones,
+                    numZoneNames,
                 )
-                if numZones > 0:
+                if numActiveZones > 0 and numZoneNames == numActiveZones:
                     systemsWithZones += 1
             if got_message is False:
                 loops += 1

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -108,6 +108,25 @@ async def test_manager_configuration_initialization(manager: Manager, caplog):
                     assert "Timeout waiting for configuration data from Lennox - this sometimes happens" in ex.message
 
 
+@pytest.mark.asyncio()
+async def test_manager_configuration_initialization_ignores_none_zone_names(manager: Manager):
+    system: lennox_system = manager.api.system_list[0]
+    system.cloud_status = "online"
+    active_zone = next(zone for zone in system.zone_list if zone.is_zone_active())
+    active_zone.name = None
+    manager._conf_init_wait_time = 1
+
+    with patch.object(manager, "messagePump") as messagePump:
+        messagePump.return_value = False
+        with patch.object(system, "config_complete") as config_complete:
+            config_complete.return_value = True
+            with patch("asyncio.sleep"):
+                with pytest.raises(S30Exception) as exc_info:
+                    await manager.configuration_initialization()
+
+    assert exc_info.value.error_code == EC_CONFIG_TIMEOUT
+
+
 class CloudPresence:
     """Helper class for testing"""
 


### PR DESCRIPTION
A recent change in message ordering for cloud connections is causing initialization to be declared complete before the zone information is processed.  Adjust wait to also verify zone names are populated.